### PR TITLE
support custom projections

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/private/MaplyCoordinateSystem_private.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/private/MaplyCoordinateSystem_private.h
@@ -29,6 +29,8 @@
     MaplyCoordinate ll,ur;
 }
 
+- (id)initWithCoordSystem:(WhirlyKit::CoordSystem *)newCoordSystem;
+
 /// Return the low level Maply Coordinate system that represents this one.
 /// The object owns this and must clean it up.
 - (WhirlyKit::CoordSystem *)getCoordSystem;

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/private/MaplyViewController_private.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/private/MaplyViewController_private.h
@@ -26,12 +26,18 @@
 {
     /// Custom map scene
     Maply::MapScene *mapScene;
+
+@protected
+    /// Coordinate system and display adapter
+    WhirlyKit::CoordSystemDisplayAdapter *coordAdapter;
     /// Maply view
     MaplyView *mapView;
+    // Flat view for 2D mode
+    MaplyFlatView * flatView;
+    // Scroll view for tethered mode
+    UIScrollView * __weak scrollView;
 
-    /// Coordinate system and display adapter
-    WhirlyKit::SphericalMercatorDisplayAdapter *coordAdapter;
-    
+@private    
     /// Our own interaction layer for adding and removing things
     MaplyInteractionLayer *mapInteractLayer;
     
@@ -47,5 +53,7 @@
     /// Current view animation (kept around so it's not released)
     NSObject *curAnimation;
 }
+
+- (void)setupFlatView;
 
 @end

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyViewController.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyViewController.mm
@@ -33,10 +33,6 @@ using namespace Maply;
 
 @implementation MaplyViewController
 {
-    // Flat view for 2D mode
-    MaplyFlatView * flatView;
-    // Scroll view for tethered mode
-    UIScrollView * __weak scrollView;
     // Content scale for scroll view mode
     float scale;
     bool scheduledToDraw;


### PR DESCRIPTION
Hi,

This small pull request is only a slight rearrangement of relevant code in classes MaplyViewController and MaplyCoordinateSystem, to allow support for custom projections.

With this change one can subclass MaplyCoordinateSystem and MaplyViewController to use a custom coordinate system in the 2D view.

The MaplyCoordinateSystem-derived class would have a custom init method which calls initWithCoordSystem: from the base class.

The MaplyViewController-derived class would have a custom loadSetup_view method, which is identical to the base class method except that it uses a custom CoordSystem and CoordSystemDisplayAdapter.

For this contribution I am choosing Transfer Ownership.  Ownership is transferred to Mousebird Consulting Inc.

Thanks
Ranen
