### PR TITLE
Add function to convert Maply screen points to geo coordinates

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyViewController.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyViewController.h
@@ -203,6 +203,11 @@
  */
 - (CGPoint)screenPointFromGeo:(MaplyCoordinate)geoCoord;
 
+/** @brief Return the geographic (lon/lat radians) coordinate for a given screen point.
+ @return Returns the geo coordinate corresponding to a given screen point.
+ */
+- (MaplyCoordinate)geoFromScreenPoint:(CGPoint)point;
+
 /** @brief Find a height that shows the given bounding box.
     @details This method will search for a height that shows the given bounding box within the view.  The search is inefficient, so don't call this a lot.
     @param The bounding box (in radians) we're trying to view.

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyViewController.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyViewController.mm
@@ -639,4 +639,22 @@ using namespace Maply;
     [mapInteractLayer userDidTap:msg];
 }
 
+
+- (MaplyCoordinate)geoFromScreenPoint:(CGPoint)point {
+  	Point3d hit;
+    WhirlyKitSceneRendererES *sceneRender = glView.renderer;
+    Eigen::Matrix4d theTransform = [mapView calcFullMatrix];
+    if ([mapView pointOnPlaneFromScreen:point transform:&theTransform frameSize:Point2f(sceneRender.framebufferWidth/glView.contentScaleFactor,sceneRender.framebufferHeight/glView.contentScaleFactor) hit:&hit clip:true])
+    {
+        Point3d localPt = coordAdapter->displayToLocal(hit);
+		GeoCoord coord = coordAdapter->getCoordSystem()->localToGeographic(localPt);
+        MaplyCoordinate maplyCoord;
+        maplyCoord.x = coord.x();
+        maplyCoord.y  = coord.y();
+        return maplyCoord;
+    } else {
+        return MaplyCoordinateMakeWithDegrees(0, 0);
+    }
+}
+
 @end


### PR DESCRIPTION
Maybe there is already an easy way to do this that I am missing?
