### PR TITLE
Implemented cached file lifetime in MaplyRemoteTileSource, fixed typo.

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyRemoteTileSource.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyRemoteTileSource.h
@@ -124,12 +124,21 @@
 
 /** @brief The cache directory for image tiles.
     @details In general, we want to cache.  The globe, in particular,
-    is going to fetch the same times over and over, quite a lot.
+    is going to fetch the same tiles over and over, quite a lot.
     The cacheing behavior is a little dumb.  It will just write
     files to the given directory forever.  If you're interacting
     with a giant image pyramid, that could be problematic.
   */
 @property (nonatomic) NSString *cacheDir;
+
+/** @brief The maximum age of a cached file in seconds.
+    @details If set, tiles in the cache older than this number of
+    seconds will not be used; rather, a new copy of the tile will be
+    retrieved from the remote source, and the locally cached tile
+    will be updated. This is useful for tiles that represent
+    impermanent data, such as weather information.
+ */
+@property (nonatomic) int cachedFileLifetime;
 
 /** @brief A delegate for tile loads and failures.
     @details If set, you'll get callbacks when the various tiles load (or don't). You get called in all sorts of threads.  Act accordingly.

--- a/WhirlyGlobeSrc/WhirlyGlobeComponentTester/WhirlyGlobeComponentTester/TestViewController.m
+++ b/WhirlyGlobeSrc/WhirlyGlobeComponentTester/WhirlyGlobeComponentTester/TestViewController.m
@@ -915,6 +915,8 @@ static const int NumMegaMarkers = 40000;
             } else if (![layerName compare:kMaplyTestOWM])
             {
                 MaplyRemoteTileSource *tileSource = [[MaplyRemoteTileSource alloc] initWithBaseURL:@"http://tile.openweathermap.org/map/precipitation/" ext:@"png" minZoom:0 maxZoom:6];
+                tileSource.cacheDir = [NSString stringWithFormat:@"%@/openweathermap_precipitation/",cacheDir];
+                tileSource.cachedFileLifetime = 3 * 60 * 60; // invalidate OWM data after three hours
                 MaplyQuadImageTilesLayer *weatherLayer = [[MaplyQuadImageTilesLayer alloc] initWithCoordSystem:tileSource.coordSys tileSource:tileSource];
                 weatherLayer.coverPoles = false;
                 layer = weatherLayer;


### PR DESCRIPTION
I also added an example of the functionality to WhirlyGlobeComponentTester/TestViewController.m.
