### PR TITLE
fix memory leak in SetupDefaultShaders

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobeLib/src/DefaultShaderPrograms.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/src/DefaultShaderPrograms.mm
@@ -393,7 +393,7 @@ void SetupDefaultShaders(Scene *scene)
         NSLog(@"SetupDefaultShaders: Triangle shader for screen space objects didn't compile.");
         delete screenShader;
     } else {
-        scene->addProgram(kToolkitDefaultScreenSpaceProgram, triShaderMultiTex);
+        scene->addProgram(kToolkitDefaultScreenSpaceProgram, screenShader);
     }
     
     OpenGLES2Program *billShader = BuildBillboardProgram();


### PR DESCRIPTION
SetupDefaultShaders was leaking memory, or at least instruments thought so, due to the screenShader not being added. Or maybe i just don't understand this code properly.
