### PR TITLE
bug fix for tile servers which serve clear tiles as 1x1 images

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyQuadImageTilesLayer.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyQuadImageTilesLayer.mm
@@ -710,6 +710,9 @@ using namespace WhirlyKit;
         // Get the data for the tile and sort out what the delegate returned to us
         id tileReturn = [_tileSource imageForTile:tileID];
         MaplyImageTile *tileData = [[MaplyImageTile alloc] initWithRandomData:tileReturn];
+        if (tileSize > 0) {
+            tileData.targetSize = CGSize{(CGFloat)tileSize, (CGFloat)tileSize};
+        }
         WhirlyKitLoadedTile *loadTile = [tileData wkTile:borderTexel convertToRaw:true];
         
         if (tileData && !loadTile)
@@ -785,6 +788,9 @@ using namespace WhirlyKit;
 
     // Get the data for the tile and sort out what the delegate returned to us
     MaplyImageTile *tileData = [[MaplyImageTile alloc] initWithRandomData:tileReturn];
+    if (tileSize > 0) {
+        tileData.targetSize = CGSize{(CGFloat)tileSize, (CGFloat)tileSize};
+    }
     WhirlyKitLoadedTile *loadTile = [tileData wkTile:borderTexel convertToRaw:true];
 
     // Start with elevation


### PR DESCRIPTION
I use a tile server which serves completely clear tiles as 1x1 PNGs to save bandwidth. I am using MaplyRemoteTileSource and these 1x1 tiles do not get added to the dynamic texture atlas properly. It only writes one pixel to the atlas, leaving the rest of the tile as uninitialized memory. This results in some clear tiles displaying incorrectly.

This patch fixes the bug by scaling images to the tile size of the layer. I used your existing targetSize functionality, so my patch only changes six lines of code.

I am attaching a screenshot that shows the bug. It has two layers on the globe - a base "Earth" layer which displays correctly, and a data layer above it that should be completely clear for this area of the map. As you can see some of the tiles are not clear.
![screenshot 2014 04 23 15 50 31](https://cloud.githubusercontent.com/assets/2142839/2784339/d5e3394a-cb3a-11e3-88c3-41e6d48d4200.png)
