### PR TITLE
Helper methods for swift users

### DIFF
--- a/WhirlyGlobeSrc/SwiftExtensions/MaplyBaseViewController_ext.swift
+++ b/WhirlyGlobeSrc/SwiftExtensions/MaplyBaseViewController_ext.swift
@@ -1,5 +1,5 @@
 //
-//  WhirlyGlobeViewController_ext.swift
+//  MaplyBaseViewController_ext.swift
 //
 
 import UIKit

--- a/WhirlyGlobeSrc/SwiftExtensions/MaplyBaseViewController_ext.swift
+++ b/WhirlyGlobeSrc/SwiftExtensions/MaplyBaseViewController_ext.swift
@@ -1,0 +1,29 @@
+//
+//  WhirlyGlobeViewControllerFacade.swift
+//
+
+import UIKit
+
+extension MaplyBaseViewController {
+
+    func addLabels(labels: [MaplyLabel], attributes attr: [MaplySharedAttribute], threadMode: MaplyThreadMode = MaplyThreadAny) -> MaplyComponentObject {
+        return addLabels(labels, desc: MaplySharedAttribute.dictionaryFromArray(attr), mode: threadMode)
+    }
+    
+    func addScreenLabels(labels: [MaplyScreenLabel], attributes attr: [MaplySharedAttribute], threadMode: MaplyThreadMode = MaplyThreadAny) -> MaplyComponentObject {
+        return addScreenLabels(labels, desc: MaplySharedAttribute.dictionaryFromArray(attr), mode: threadMode)
+    }
+    
+    func addScreenMarkers(markers: [MaplyScreenMarker], attributes attr: [MaplySharedAttribute], threadMode: MaplyThreadMode = MaplyThreadAny) -> MaplyComponentObject {
+        return addScreenMarkers(markers, desc: MaplySharedAttribute.dictionaryFromArray(attr), mode: threadMode)
+    }
+    
+    func addMarkers(markers: [MaplyMarker], attributes attr: [MaplySharedAttribute], threadMode: MaplyThreadMode = MaplyThreadAny) -> MaplyComponentObject {
+        return addMarkers(markers, desc: MaplySharedAttribute.dictionaryFromArray(attr), mode: threadMode)
+    }
+    
+    func addVectors(vectors: [MaplyVectorObject], attributes attr: [MaplySharedAttribute], mode threadMode: MaplyThreadMode = MaplyThreadAny) -> MaplyComponentObject {
+        return addVectors(vectors, desc: MaplySharedAttribute.dictionaryFromArray(attr), mode: threadMode)
+    }
+    
+}

--- a/WhirlyGlobeSrc/SwiftExtensions/MaplyBaseViewController_ext.swift
+++ b/WhirlyGlobeSrc/SwiftExtensions/MaplyBaseViewController_ext.swift
@@ -1,5 +1,5 @@
 //
-//  WhirlyGlobeViewControllerFacade.swift
+//  WhirlyGlobeViewController_ext.swift
 //
 
 import UIKit

--- a/WhirlyGlobeSrc/SwiftExtensions/MaplySharedAttribute.swift
+++ b/WhirlyGlobeSrc/SwiftExtensions/MaplySharedAttribute.swift
@@ -1,6 +1,5 @@
 //
 //  MaplySharedAttribute.swift
-//  overlanding
 //
 // The idea is to use enums instead of string to name the keys, and use an array of keys instead 
 // of a dictionary of strings, so that it can be type checked and auto-completed in XCode

--- a/WhirlyGlobeSrc/SwiftExtensions/MaplySharedAttribute.swift
+++ b/WhirlyGlobeSrc/SwiftExtensions/MaplySharedAttribute.swift
@@ -1,0 +1,83 @@
+//
+//  MaplySharedAttribute.swift
+//  overlanding
+//
+// The idea is to use enums instead of string to name the keys, and use an array of keys instead 
+// of a dictionary of strings, so that it can be type checked and auto-completed in XCode
+// Enums in swift are polymorphic but typechecked, so that it's impossible to add, say, a string
+// as a value for kMaplyFont
+//
+// Partial implementation only, need to extend it to support all possible keys
+//
+// Sample usage:
+//     let labelStyle = [
+//        kMaplyFont: UIFont.boldSystemFontOfSize(48.0),
+//        kMaplyTextOutlineColor: UIColor.blackColor(),
+//        kMaplyTextOutlineSize: 2.0,
+//        kMaplyTextColor: UIColor(white: 1, alpha: 0.7)
+//    ]
+
+import UIKit
+
+enum MaplySharedAttribute {
+    
+    case Filled(Bool)
+    case Color(UIColor)
+    case Selectable(Bool)
+    case VecWidth(Float)
+    case DrawPriority(Int)
+    case TextColor(UIColor)
+    case BackgroundColor(UIColor)
+    case Font(UIFont)
+    case LabelHeight(Float)
+    case LabelWidth(Float)
+    case TextOutlineColor(UIColor)
+    case TextOutlineSize(Float)
+    
+    func addAttributeToDictionary(inout dictionary: [NSObject: AnyObject]) {
+        switch self {
+        case .Filled(let value): dictionary[kMaplyFilled] = value
+        case .Color(let value): dictionary[kMaplyColor] = value
+        case .Selectable(let value): dictionary[kMaplySelectable] = value
+        case .VecWidth(let value): dictionary[kMaplyVecWidth] = value
+        case .DrawPriority(let value): dictionary[kMaplyDrawPriority] = value
+        case .TextColor(let value): dictionary[kMaplyTextColor] = value
+        case .BackgroundColor(let value): dictionary[kMaplyBackgroundColor] = value
+        case .Font(let value): dictionary[kMaplyFont] = value
+        case .LabelHeight(let value): dictionary[kMaplyLabelHeight] = value
+        case .LabelWidth(let value): dictionary[kMaplyLabelWidth] = value
+        case .TextOutlineColor(let value): dictionary[kMaplyTextOutlineColor] = value
+        case .TextOutlineSize(let value): dictionary[kMaplyTextOutlineSize] = value
+        default: println("Unknown MaplySharedAttribute value: \(self)")
+        }
+    }
+    
+    func stringKey() -> String {
+        switch self {
+        case .Filled: return kMaplyFilled
+        case .Color: return kMaplyColor
+        case .Selectable: return kMaplySelectable
+        case .VecWidth: return kMaplyVecWidth
+        case .DrawPriority: return kMaplyDrawPriority
+        case .TextColor: return kMaplyTextColor
+        case .BackgroundColor: return kMaplyBackgroundColor
+        case .Font: return kMaplyFont
+        case .LabelHeight: return kMaplyLabelHeight
+        case .LabelWidth: return kMaplyLabelWidth
+        case .TextOutlineColor: return kMaplyTextOutlineColor
+        case .TextOutlineSize: return kMaplyTextOutlineSize
+        default: return ""
+        }
+    }
+    
+
+    static func dictionaryFromArray(array: [MaplySharedAttribute]) -> [NSObject: AnyObject] {
+        var result = [NSObject: AnyObject]()
+        for obj in array {
+            obj.addAttributeToDictionary(&result)
+        }
+        return result
+    }
+    
+}
+


### PR DESCRIPTION
Swift brings stronger type-checking to Xcode, but ObjC-bridged frameworks are full of AnyObject's and Any's. The idea is to add overloaded methods that take type-checked arguments to help catch bugs early. Class extensions make it opt-in.

Adds a small processing time to "encode" attributes into a dictionary to pass along.

Ideally, the base ObjC implementation could use "modern" ENUMs instead of string keys, which would be bridged cost-free to swift.