### PR TITLE
Close sqlite connection at MaplyMBTileSource

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyMBTileSource.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyMBTileSource.mm
@@ -199,5 +199,9 @@ using namespace WhirlyKit;
     return NO;
 }
 
+-(void) dealloc{
+    if (_sqlDb)
+        sqlite3_close(_sqlDb);
+}
 
 @end


### PR DESCRIPTION
MaplyMBTileSource didn't close the sqlite3 connection.

This pull request fix also the issue: https://github.com/mousebird/WhirlyGlobe/issues/248