### PR TITLE
Move import of SMCalloutView to MaplyAnnotation.mm

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/private/MaplyAnnotation_private.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/private/MaplyAnnotation_private.h
@@ -19,8 +19,9 @@
  */
 
 #import "MaplyAnnotation.h"
-#import "SMCalloutView.h"
 #import "MaplyCoordinate.h"
+
+@class SMCalloutView;
 
 @interface MaplyAnnotation()
 

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyAnnotation.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyAnnotation.mm
@@ -20,6 +20,7 @@
 
 #import "MaplyAnnotation_private.h"
 #import "WhirlyGlobe.h"
+#import "SMCalloutView.h"
 
 @implementation MaplyAnnotation
 


### PR DESCRIPTION
Because i need to be able to import the private header to access the loc property to determine if an annotation is currently on screen