### PR TITLE
Label rotation changes/fixes

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTextStyle.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTextStyle.mm
@@ -204,7 +204,7 @@ typedef enum {
                         //TODO: rotation calculation is not ideal, it is between 2 points, but it needs to be avergared over a longer distance
                         label.loc = middle;
                         label.layoutPlacement = kMaplyLayoutCenter;
-                        label.rotation = rot+M_PI/2.0;
+                        label.rotation = -1 * rot+M_PI/2.0;
                         label.keepUpright = true;
                     } else {
                         label = nil;

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTextStyle.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTextStyle.mm
@@ -205,6 +205,10 @@ typedef enum {
                         label.loc = middle;
                         label.layoutPlacement = kMaplyLayoutCenter;
                         label.rotation = -1 * rot+M_PI/2.0;
+                        if(label.rotation > M_PI_2 || label.rotation < -M_PI_2) {
+                            label.rotation += M_PI;
+                        }
+
                         label.keepUpright = true;
                     } else {
                         label = nil;

--- a/WhirlyGlobeSrc/WhirlyGlobeLib/src/LayoutManager.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/src/LayoutManager.mm
@@ -434,23 +434,23 @@ bool LayoutManager::runLayoutRules(WhirlyKitViewState *viewState)
                         {
                                 //center
                             case 0:
-                                objOffset = Point2d(-layoutSpan.x()/2.0,0.0);
+                                objOffset = Point2d(-layoutSpan.x()/2.0,layoutSpan.y()/2.0);
                                 break;
                                 // Right
                             case 1:
-                                objOffset = Point2d(0.0,0.0);
+                                objOffset = Point2d(0.0,layoutSpan.y()/2.0);
                                 break;
                                 // Left
                             case 2:
-                                objOffset = Point2d(-(layoutSpan.x()),0.0);
+                                objOffset = Point2d(-(layoutSpan.x()),layoutSpan.y()/2.0);
                                 break;
                                 // Above
                             case 3:
-                                objOffset = Point2d(-layoutSpan.x()/2.0,-(layoutSpan.y())/2.0);
+                                objOffset = Point2d(-layoutSpan.x()/2.0,0);
                                 break;
                                 // Below
                             case 4:
-                                objOffset = Point2d(-layoutSpan.x()/2.0,(layoutSpan.y())/2.0);
+                                objOffset = Point2d(-layoutSpan.x()/2.0,layoutSpan.y());
                                 break;
                         }
                         


### PR DESCRIPTION
The contains one change that is definitely a bug fix, and a few changes that are debatable whether they are changes or bug fixes.

bug fix: rotation for labels in MaplyVectorTextStyle with line placement was backwards.

features:
1. Label placement seems to be based on the text baseline, IIRC it used to be based on the vertical center of the text, but the offset calculations for acceptablePlacement haven't changed to reflect that.
2. MaplyVectorTextStyle labels with line placement could be upside down, this makes it so they are always right side up.


A couple screenshots for feature 1:
![Before](https://cloud.githubusercontent.com/assets/2048291/8907871/fb7b27b6-3435-11e5-9433-d949616baa78.png)
![After](https://cloud.githubusercontent.com/assets/2048291/8907863/f17873f4-3435-11e5-96ca-191377b730fc.png)
