### PR TITLE
Updates to make 2.4.1 build a swift module for use in a playground.

### DIFF
--- a/WhirlyGlobe.podspec
+++ b/WhirlyGlobe.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "WhirlyGlobe"
-  s.version          = "2.4"
+  s.version          = "2.4.1"
   s.summary          = "WhirlyGlobe-Maply: Geospatial visualization for iOS and Android."
   s.description      = <<-DESC
                         WhirlyGlobe-Maply is a high performance geospatial display toolkit for iOS and Android.
@@ -28,38 +28,43 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/mousebird/WhirlyGlobe.git', :tag => 'v2.4_beta1' }
 
   s.compiler_flags = '-D__USE_SDL_GLES__', '-D__IPHONEOS__'
-  s.xcconfig = { "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/boost\" \"${PODS_ROOT}/eigen\" \"${PODS_ROOT}/clipper\" \"$(SDKROOT)/usr/include/libxml2\"" }
+  s.xcconfig = { "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/boost\" \"${PODS_ROOT}/eigen\" \"${PODS_ROOT}/clipper\" \"$(SDKROOT)/usr/include/libxml2\"",
+		'ALWAYS_SEARCH_USER_PATHS' => 'YES'
+   }
 
   s.default_subspec = 'MaplyComponent'
 
   s.subspec 'glues-wg' do |gl|
     gl.source_files = 'WhirlyGlobeSrc/local_libs/glues/**/*.{c,h}'
-    gl.resources = 'WhirlyGlobeSrc/local_libs/glues/**/*.{i}'
-#    gl.private_header_files = 'WhirlyGlobeSrc/local_libs/glues/**/*.i'
-#    gl.public_header_files = 'WhirlyGlobeSrc/local_libs/glues/include/**/*.h'
+    gl.preserve_paths = 'WhirlyGlobeSrc/local_libs/glues/**/*.i'
+    gl.private_header_files = 'WhirlyGlobeSrc/local_libs/glues/**/*.h'
     gl.header_mappings_dir = 'include/'
     gl.header_mappings_dir = 'SDL'
   end
 
   s.subspec 'shapefile' do |shp|
     shp.source_files = 'WhirlyGlobeSrc/local_libs/shapefile/**/*.{c,h}'
+    shp.private_header_files = 'WhirlyGlobeSrc/local_libs/shapefile/**/*.h'
   end
 
   s.subspec 'kissxml' do |kss|
     kss.source_files = 'WhirlyGlobeSrc/local_libs/KissXML/**/*.{h,m}'
+    kss.private_header_files = 'WhirlyGlobeSrc/local_libs/KissXML/**/*.h'
   end
 
   s.subspec 'aaplus' do |aa|
     aa.source_files = 'WhirlyGlobeSrc/local_libs/aaplus/**/*.{h,cpp}'
+    aa.private_header_files = 'WhirlyGlobeSrc/local_libs/aaplus/**/*.h'
   end
 
   s.subspec 'octencoding' do |oe|
     oe.source_files = 'WhirlyGlobeSrc/local_libs/octencoding/**/*.h'
+    oe.private_header_files = 'WhirlyGlobeSrc/local_libs/octencoding/**/*.h'
   end
 
   s.subspec 'Lib-Headers' do |lh|
     lh.source_files = 'WhirlyGlobeSrc/WhirlyGlobeLib/include/*.h'
-    lh.public_header_files = 'WhirlyGlobeSrc/WhirlyGlobeLib/include/*.h'
+    lh.private_header_files = 'WhirlyGlobeSrc/WhirlyGlobeLib/include/*.h'
     lh.dependency 'boost/string_algorithms-includes', '<= 1.51.0'
     lh.dependency 'boost/shared_ptr-includes', '<= 1.51.0'
     lh.dependency 'boost/pointer_cast-includes', '<= 1.51.0'
@@ -85,6 +90,7 @@ Pod::Spec.new do |s|
     mch.source_files = 'WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/**/*.h'
 #    mch.private_header_files = 'WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/private/*.h'
 #    mch.public_header_files = 'WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/*.h'
+    mch.private_header_files =  "WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/**/{MaplyComponent,WhirlyGlobeComponent,MaplyBridge,vector_tile.pb}.h", "WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/private/*.h"
     mch.dependency 'WhirlyGlobe/Lib-Headers'
   end
 

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyAnnotation.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyAnnotation.h
@@ -19,7 +19,7 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <MaplyCoordinate.h>
+#import "MaplyCoordinate.h"
 
 /** @brief This object displays an annotation at a particular point and will track that point as the map or globe moves.
     @details An annotation is used to point out some feature on the globe or map, typically that the user has tapped on.  It's a multi-part beast that may contain titles, subtitles, images, background views and such.

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplySticker.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplySticker.h
@@ -19,8 +19,8 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <MaplyCoordinate.h>
-#import <MaplyQuadImageTilesLayer.h>
+#import "MaplyCoordinate.h"
+#import "MaplyQuadImageTilesLayer.h"
 
 /** @brief Stickers are rectangles placed on the globe with an image.
     @details The Maply Sticker will stretch a rectangle (in geographic) over the given extents and tack the given image on top of it.  Stickers differ from MaplyMarker objects in that they're big.  They can stretch over a larger are and need to be subdivided as such.

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyVectorObject.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyVectorObject.h
@@ -20,8 +20,8 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import <MaplyCoordinate.h>
-#import <MaplyCoordinateSystem.h>
+#import "MaplyCoordinate.h"
+#import "MaplyCoordinateSystem.h"
 
 @class MaplyBaseViewController;
 

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyViewController.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyViewController.h
@@ -19,7 +19,7 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <MaplyCoordinate.h>
+#import "MaplyCoordinate.h"
 #import "MaplyScreenMarker.h"
 #import "MaplyVectorObject.h"
 #import "MaplyViewTracker.h"


### PR DESCRIPTION
Here are the changes against WhirlyGlobe develop_2_4_1.  Honestly, it looks like they can be made against WhirlyGlobe 2.4, and enable Swift development with the 2.4 release.