### PR TITLE
Fix letter case of includes to match files

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobeLib/include/ShapeDrawableBuilder.h
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/include/ShapeDrawableBuilder.h
@@ -21,7 +21,7 @@
 #import "Identifiable.h"
 #import "WhirlyVector.h"
 #import "DataLayer.h"
-#import "layerThread.h"
+#import "LayerThread.h"
 
 /// Used to pass shape info between the shape layer and the drawable builder
 ///  and within the threads of the shape layer

--- a/WhirlyGlobeSrc/WhirlyGlobeLib/include/ShapeManager.h
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/include/ShapeManager.h
@@ -21,7 +21,7 @@
 #import "Identifiable.h"
 #import "WhirlyVector.h"
 #import "DataLayer.h"
-#import "layerThread.h"
+#import "LayerThread.h"
 #import "SelectionManager.h"
 #import "Scene.h"
 


### PR DESCRIPTION
Building in a case-sensitive filesystem environment requires these very minor changes.