### PR TITLE
Recognize tiles compressed with gzip and non-default zlib levels

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/NSData+Zlib.m
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/NSData+Zlib.m
@@ -24,9 +24,26 @@
 @implementation NSData(zlib)
 - (BOOL)isCompressed
 {
-  	return self.length > 2 &&
-      (uint8_t)((const char*)self.bytes)[0] == 0x78 &&
-      (uint8_t)((const char*)self.bytes)[1] == 0x9C;
+    uint32_t const smallest_zlib_output = 8;    // gzip is 23
+    if (self.length >= smallest_zlib_output)
+    {
+        const uint8_t* const bytes = (const uint8_t*)self.bytes;
+        switch (bytes[0])
+        {
+            case 0x1f:
+                return (bytes[1] == 0x8b);  // gzip
+            case 0x78:
+                switch (bytes[1])
+                {
+                    case 0x01:  // Compression levels 0-1 (none,fast)
+                    case 0x5e:  // Compression levels 2-5
+                    case 0x9c:  // Compression level  6   (default)
+                    case 0xda:  // Compression levels 7-9 (best)
+                        return true;
+                }
+        }
+    }
+    return false;
 }
 
 


### PR DESCRIPTION
I was trying to load up an mbtiles file generated by [tippecanoe](https://github.com/mapbox/tippecanoe) in Maply, and it just generated a lot of "Failed to parse tile:" errors in the console.

After a little troubleshooting, I found that `isCompressed` was returning false, despite the fact that tippecanoe compresses the tile data, leading to compressed data being passed to the protobuf deserializer which, of course, fails.

After a little research, I found that the bytes being checked (78/9c) are specific to the zlib header at compression level 6 (default).  [\[1\]](http://stackoverflow.com/a/30794147/135138)  Other compression options yield one of several other possibilities for the second byte.

Tippecanoe passes `windowSize=15+16` to `deflateInit2`, causing it to produce a gzip wrapper instead of zlib.  The GZip header signature is 1f/8b [\[2\]](http://www.gzip.org/zlib/rfc-gzip.html).

In Maply, the `uncompressGZip` already function passes `windowSize=15+32` to `inflateInit2` which, according to the documentation, causes it to accept either the gzip or zlib header/footer formats, so I've modified the `isCompressed` function to recognize the header bytes for either format, including zlib-compressed data with compression levels other than 6.

This does slightly increase the chances of a false-positive, but it may be that no valid protobuf message can actually produce these values. If it's possible, it might make sense to continue with deserialization on the raw data if decompression fails.

It would also be possible to save 6-21 bytes per tile by allowing "raw zlib" compression (which is done by passing a negative window size to `deflateInit2`), and using a flag in the metadata, or something, to indicate that the tiles are compressed that way rather than checking on a per-tile basis.
