### PR TITLE
Pause the CADisplayLink when going into the background

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyBaseViewController.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyBaseViewController.mm
@@ -314,6 +314,7 @@ using namespace WhirlyKit;
         if (wasAnimating)
             [self stopAnimation];
     }
+    [glView pause];
     for(WhirlyKitLayerThread *t in layerThreads)
     {
         [t pause];
@@ -326,6 +327,7 @@ using namespace WhirlyKit;
     {
         [t unpause];
     }
+    [glView unpause];
     if (wasAnimating)
     {
         [self startAnimation];

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyBaseViewController.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyBaseViewController.mm
@@ -337,8 +337,9 @@ using namespace WhirlyKit;
 
 - (void)viewWillAppear:(BOOL)animated
 {
-	[self startAnimation];
-	
+    [glView unpause];
+  [self startAnimation];
+
 	[super viewWillAppear:animated];
 }
 
@@ -347,6 +348,7 @@ using namespace WhirlyKit;
 	[super viewWillDisappear:animated];
 
 	[self stopAnimation];
+    [glView pause];
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation

--- a/WhirlyGlobeSrc/WhirlyGlobeLib/include/EAGLView.h
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/include/EAGLView.h
@@ -49,6 +49,11 @@
 /// Destroy the display link.  Cannot be restarted.
 - (void) shutdown;
 
+/// Pause the display link. Used when going into the background
+- (void) pause;
+/// Unpause the display link. Used when going returning to foreground
+- (void) unpause;
+
 /// Draw into the actual view
 - (void) drawView:(id)sender;
 

--- a/WhirlyGlobeSrc/WhirlyGlobeLib/src/EAGLView.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/src/EAGLView.mm
@@ -184,4 +184,21 @@
 }
 
 
+
+- (void) pause {
+    if(displayLink)
+    {
+        displayLink.paused = YES;
+    }
+}
+
+
+- (void) unpause {
+    if(displayLink)
+    {
+        displayLink.paused = NO;
+    }
+}
+
+
 @end


### PR DESCRIPTION
If you have a background mode this does not happen automatically.

Keeping it running wastes battery, and has the potential to cause a crash if an animation is in progress when the app enters the background.