### PR TITLE
Android MBTile reader first implementation

### DIFF
--- a/WhirlyGlobeSrc/Android/Android.iml
+++ b/WhirlyGlobeSrc/Android/Android.iml
@@ -75,7 +75,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
@@ -86,7 +85,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
@@ -94,11 +92,11 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="okio-1.3.0" level="project" />
-    <orderEntry type="library" exported="" name="org.apache.commons.io-2.4" level="project" />
     <orderEntry type="library" exported="" name="commons-io-2.4" level="project" />
     <orderEntry type="library" exported="" name="okhttp-2.3.0" level="project" />
     <orderEntry type="library" exported="" name="support-v4-23.0.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.0.0" level="project" />
+    <orderEntry type="library" exported="" name="okio-1.3.0" level="project" />
+    <orderEntry type="library" exported="" name="org.apache.commons.io-2.4" level="project" />
   </component>
 </module>

--- a/WhirlyGlobeSrc/Android/build.gradle
+++ b/WhirlyGlobeSrc/Android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.jfrog.bintray'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23"
+    buildToolsVersion "23.0.1"
 
     sourceSets {
         main {

--- a/WhirlyGlobeSrc/Android/src/com/mousebird/maply/MBTilesSource.java
+++ b/WhirlyGlobeSrc/Android/src/com/mousebird/maply/MBTilesSource.java
@@ -19,20 +19,152 @@
  */
 package com.mousebird.maply;
 
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.AsyncTask;
+import android.util.Log;
+
+import java.io.File;
+
 /**
  * The MBTiles Source reads Mapbox style MBTiles files.
  */
 public class MBTilesSource implements QuadImageTileLayer.TileSource
 {
-    int minZoom=0,maxZoom=0;
-    int pixelsPerSide=256;
+
+    //***********************************************************************//
+    //                           Inner classes                               //
+    //***********************************************************************//
+
+    private class FetchTileAsyncTask extends AsyncTask<MaplyTileID, Integer, Boolean> {
+
+
+        private QuadImageTileLayerInterface layer;
+        private int frame;
+
+        public FetchTileAsyncTask(QuadImageTileLayerInterface layer, int frame) {
+            this.layer = layer;
+            this.frame = frame;
+        }
+
+        @Override
+        protected Boolean doInBackground(MaplyTileID... tileIDs) {
+
+            Log.v(TAG, String.format("Fetching %d tiles...", tileIDs.length));
+
+            for (MaplyTileID tileID : tileIDs) {
+
+                String[] params = new String[3];
+                params[0] = Integer.toString(tileID.level);
+                params[1] = Integer.toString(tileID.x);
+                params[2] = Integer.toString(tileID.y);
+
+                Cursor c = mbTileDb.rawQuery(GET_TILE_SQL, params);
+
+                int tileDataIdx = c.getColumnIndex(TILE_DATA);
+
+                if (c.getCount() > 0) {
+                    c.moveToFirst();
+
+                    byte[] image = c.getBlob(tileDataIdx);
+                    Bitmap bm = BitmapFactory.decodeByteArray(image, 0, image.length);
+
+                    MaplyImageTile tile = new MaplyImageTile(bm);
+
+                    layer.loadedTile(tileID, frame, tile);
+
+                    Log.v(TAG, String.format("Returned tile for Z=%s, X=%d, Y=%d", tileID.level, tileID.x, tileID.y));
+
+                } else {
+                    Log.i(TAG, String.format("Could not find tile for Z=%s, X=%d, Y=%d", tileID.level, tileID.x, tileID.y));
+                }
+
+                c.close();
+            }
+
+            return null;
+        }
+    }
+
+
+    //***********************************************************************//
+    //                          Class variables                              //
+    //***********************************************************************//
+
+    private static String TAG = MBTilesSource.class.getSimpleName();
+
+    private static String BOUNDS = "bounds";
+    private static String MINZOOM = "minzoom";
+    private static String MAXZOOM = "maxzoom";
+    private static String TYPE = "type";
+    private static String DESCRIPTION = "description";
+    private static String FORMAT = "format";
+
+    private static String NAME = "name";
+    private static String VALUE = "value";
+    private static String PNG = "png";
+    private static String JPG = "jpg";
+
+    private static String GET_TILE_SQL = "SELECT tile_data from tiles where zoom_level = ? AND tile_column = ? AND tile_row= ?;";
+    private static String TILE_DATA = "tile_data";
+
+
+
+
+
+
+
+    //***********************************************************************//
+    //                         Instance variables                            //
+    //***********************************************************************//
+
+    private int minZoom = -1, maxZoom = -1;
+    private int pixelsPerSide = 256;
+
+    private SQLiteDatabase mbTileDb;
+
+    private boolean initialized;    // Have we been correctly initialized
+    private boolean oldStyleDB;     // Are we managing an old style database
+    private boolean isJpg;          // Are we containing jpg tiles (or png tiles)
+
+    private String name = "UNSET";            // Name of the tile dataset
+    private String description = "UNSET";     // Description of the tile dataset
+    private String type = "UNSET";            // Type of tile (overlay | baselayer)
+
+
+    //***********************************************************************//
+    //                            Constructors                               //
+    //***********************************************************************//
+
 
     public MBTilesSource(String mbTileFileName)
     {
         // Note: Do the initial read from the database to get the header info
         //       This includes min and max zoom as well as anything you need
         //       to know about reading the rest of it.
+
+        // We look for the file into assets
     }
+
+    public MBTilesSource(File mbTileFile) {
+
+        if (mbTileFile == null || !mbTileFile.exists() || !mbTileFile.canRead()) {
+            String message = String.format("MBTileSource must be initialized with an existing file. \"%s\" does not exists or is null...",
+                    (mbTileFile == null ? "#NULL" : mbTileFile.getAbsolutePath())) ;
+            Log.e(TAG, message);
+            assert true : message;
+        }
+
+        this.init(mbTileFile);
+
+    }
+
+
+    //***********************************************************************//
+    //                         Getters and setters                           //
+    //***********************************************************************//
 
     /**
      * The minimum zoom level you'll be called about to create a tile for.
@@ -61,6 +193,11 @@ public class MBTilesSource implements QuadImageTileLayer.TileSource
     // The coordinate system for these is almost always spherical mercator
     public CoordSystem coordSys = new SphericalMercatorCoordSystem();
 
+
+    //***********************************************************************//
+    //                           Public methods                              //
+    //***********************************************************************//
+
     /**
      * This tells you when to start fetching a given tile. When you've fetched
      * the image you'll want to call loadedTile().  If you fail to fetch an image
@@ -70,9 +207,124 @@ public class MBTilesSource implements QuadImageTileLayer.TileSource
      * @param tileID The tile ID to fetch.
      * @param frame If the source support multiple frames, this is the frame.  Otherwise -1.
      */
-    public void startFetchForTile(QuadImageTileLayerInterface layer,MaplyTileID tileID,int frame)
+    public void startFetchForTile(QuadImageTileLayerInterface layer, MaplyTileID tileID, int frame)
     {
         // Note: Start the fetch for a single tile, ideally on another thread.
         //       When the tile data is in, call the layer loadedTile() method.
+
+        Log.v(TAG, String.format("Requested to fetch tile for Z=%s, X=%d, Y=%d", tileID.level, tileID.x, tileID.y));
+
+        String[] params = new String[3];
+        params[0] = Integer.toString(tileID.level);
+        params[1] = Integer.toString(tileID.x);
+        params[2] = Integer.toString(tileID.y);
+
+        Cursor c = mbTileDb.rawQuery(GET_TILE_SQL, params);
+
+        int tileDataIdx = c.getColumnIndex(TILE_DATA);
+
+        if (c.getCount() > 0) {
+            c.moveToFirst();
+
+            byte[] image = c.getBlob(tileDataIdx);
+            Bitmap bm = BitmapFactory.decodeByteArray(image, 0, image.length);
+
+            MaplyImageTile tile = new MaplyImageTile(bm);
+
+            layer.loadedTile(tileID, frame, tile);
+
+            Log.v(TAG, String.format("Returned tile for Z=%s, X=%d, Y=%d", tileID.level, tileID.x, tileID.y));
+
+        } else {
+            Log.i(TAG, String.format("Could not find tile for Z=%s, X=%d, Y=%d", tileID.level, tileID.x, tileID.y));
+        }
+
+        c.close();
+
+    }
+
+
+    //***********************************************************************//
+    //                           Private methods                             //
+    //***********************************************************************//
+
+    /**
+     * Initializes the MBTilesSource with an SQLite database.
+     * @param sqliteDb a File mapped to an <b>existing</b> SQLite database. The file must exists beforehand.
+     */
+    private void init(File sqliteDb)
+    {
+        mbTileDb = SQLiteDatabase.openDatabase(sqliteDb.getAbsolutePath(), null, SQLiteDatabase.OPEN_READONLY);
+
+        // We read metadata
+        String sql = "SELECT name, value FROM metadata;";
+
+        Cursor c = mbTileDb.rawQuery(sql, null);
+
+        if (c.getCount() > 0) {
+            c.moveToFirst();
+
+            int nameIdx = c.getColumnIndexOrThrow(NAME);
+            int valueIdx = c.getColumnIndexOrThrow(VALUE);
+
+            while (!c.isAfterLast()) {
+
+                // What parameter are we reading
+                String meta = c.getString(nameIdx);
+
+                if (MAXZOOM.equals(meta)) {
+                    maxZoom = c.getInt(valueIdx);
+                }
+
+                if (MINZOOM.equals(meta)) {
+                    minZoom = c.getInt(valueIdx);
+                }
+
+                if (FORMAT.equals(meta)) {
+                    String format = c.getString(valueIdx);
+                    if (JPG.equals(format)) {
+                        isJpg = true;
+                    }
+                }
+
+                if (NAME.equals(meta)) {
+                    name = c.getString(valueIdx);
+                }
+
+                if (DESCRIPTION.equals(meta)) {
+                    description =  c.getString(valueIdx);
+                }
+
+                c.moveToNext();
+            }
+        }
+
+        c.close();
+
+
+        // If we did not get a minZoom and maxZoom, we need to get them the hard way
+        if (minZoom == -1 || maxZoom == -1) {
+
+            sql = "SELECT MIN(zoom) AS minzoom, MAX(zoom) as maxzoom FROM tiles;";
+
+            c = mbTileDb.rawQuery(sql, null);
+
+            if (c.getCount() > 0) {
+
+                c.moveToFirst();
+
+                minZoom = c.getInt(c.getColumnIndexOrThrow(MINZOOM));
+                maxZoom = c.getInt(c.getColumnIndexOrThrow(MAXZOOM));
+            }
+
+            c.close();
+            Log.i(TAG, "Got MIN & MAX zoom the hard way...");
+        }
+
+        Log.v(TAG, String.format("Initialized MBTilesSource %s (%s)", name, description));
+        Log.v(TAG, String.format("  > Zoom %d -> %d", minZoom, maxZoom));
+        Log.v(TAG, String.format("  > Type \"%s\"", type));
+        Log.v(TAG, String.format("  > Format \"%s\"", (isJpg ? "jpg" : "png")));
+
     }
 }

--- a/WhirlyGlobeSrc/AutoTesterAndroid/.idea/misc.xml
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/.idea/misc.xml
@@ -1,5 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <entry_points version="2.0" />
+  </component>
+  <component name="NullableNotNullManager">
+    <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
+    <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
+    <option name="myNullables">
+      <value>
+        <list size="4">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
+          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
+          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.Nullable" />
+        </list>
+      </value>
+    </option>
+    <option name="myNotNulls">
+      <value>
+        <list size="4">
+          <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
+          <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
+          <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
+          <item index="3" class="java.lang.String" itemvalue="android.support.annotation.NonNull" />
+        </list>
+      </value>
+    </option>
+  </component>
   <component name="ProjectLevelVcsManager" settingsEditedManually="false">
     <OptionsSetting value="true" id="Add" />
     <OptionsSetting value="true" id="Remove" />
@@ -10,26 +37,10 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">
     <option name="id" value="Android" />
-  </component>
-  <component name="masterDetails">
-    <states>
-      <state key="ProjectJDKs.UI">
-        <settings>
-          <last-edited>Android API 19 Platform</last-edited>
-          <splitter-proportions>
-            <option name="proportions">
-              <list>
-                <option value="0.2" />
-              </list>
-            </option>
-          </splitter-proportions>
-        </settings>
-      </state>
-    </states>
   </component>
 </project>

--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/build.gradle
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.0"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "com.mousebirdconsulting.autotester"

--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/assets/mbtiles/.gitignore
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/assets/mbtiles/.gitignore
@@ -1,0 +1,1 @@
+geography-class.mbtiles

--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/MBTilesImageTestCase.java
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/MBTilesImageTestCase.java
@@ -1,6 +1,9 @@
 package com.mousebirdconsulting.autotester.TestCases;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.util.Log;
 
 import com.mousebird.maply.GlobeController;
 import com.mousebird.maply.MBTilesSource;
@@ -10,19 +13,44 @@ import com.mousebird.maply.QuadImageTileLayer;
 import com.mousebirdconsulting.autotester.ConfigOptions;
 import com.mousebirdconsulting.autotester.Framework.MaplyTestCase;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 /**
  * Created by sjg on 4/11/16.
  */
 public class MBTilesImageTestCase extends MaplyTestCase {
+
+    private static String TAG = "AutoTester";
+    private static String MBTILES_DIR = "mbtiles";
+
+    private Activity activity;
+
     public MBTilesImageTestCase(Activity activity) {
         super(activity);
         setTestName("MBTiles Image Test");
         setDelay(1000);
+
+        this.activity = activity;
     }
 
     private QuadImageTileLayer setupImageLayer(MaplyBaseController baseController, ConfigOptions.TestType testType) throws Exception
     {
-        MBTilesSource tileSource = new MBTilesSource("TestFile.sqlite");
+
+        // We need to copy the file from the asset so that it can be used as a file
+        File mbTiles = this.getMbTileFile("mbtiles/geography-class.mbtiles", "geography-class.mbtiles");
+
+        if (!mbTiles.exists()) {
+            throw new FileNotFoundException(String.format("Could not copy MBTiles asset to \"%s\"", mbTiles.getAbsolutePath()));
+        }
+
+        Log.d(TAG, String.format("Obtained MBTiles SQLLite database \"%s\"", mbTiles.getAbsolutePath()));
+
+        MBTilesSource tileSource = new MBTilesSource(mbTiles);
         QuadImageTileLayer imageLayer = new QuadImageTileLayer(baseController, tileSource.coordSys, tileSource);
         imageLayer.setCoverPoles(true);
         imageLayer.setHandleEdges(true);
@@ -41,4 +69,37 @@ public class MBTilesImageTestCase extends MaplyTestCase {
         mapVC.addLayer(setupImageLayer(mapVC, ConfigOptions.TestType.MapTest));
         return true;
     }
+
+
+
+    private File getMbTileFile(String assetMbTile, String mbTileFilename) throws IOException {
+
+        ContextWrapper wrapper = new ContextWrapper(activity);
+        File mbTilesDirectory =  wrapper.getDir(MBTILES_DIR, Context.MODE_PRIVATE);
+
+        InputStream is = activity.getAssets().open(assetMbTile);
+        File of = new File(mbTilesDirectory, mbTileFilename);
+
+        if (of.exists()) {
+            return of;
+        }
+
+        OutputStream os = new FileOutputStream(of);
+        byte[] mBuffer = new byte[1024];
+        int length;
+        while ((length = is.read(mBuffer))>0) {
+            os.write(mBuffer, 0, length);
+        }
+        os.flush();
+        os.close();
+        is.close();
+
+        return of;
+
+    }
+
+
+
+
+    
 }


### PR DESCRIPTION
Steve, 
here is a functional implementation of the MBTile reader.
I struggled with the test app (UI seems beyond my understanding, but this is not the point) but it worked.
You will need to copy the geography-class.mbtiles from the resources directory to the assets/mbtiles directory of the AutoTester project (I excluded it in the .gitignore, it is not worth checking in twice).

2 caveats though:
- I pass a File object to the reader, not a String (asset name). Dealing with an asset name in the reader would require accessing a Context object. Nothing impossible, but not necessarily a big advantage and there are some risks. Using a file leaves more flexibility to the user and marks responsibilities more clearly.

- This works for bitmap MBTiles and it can probably be used as a base for a vector reader, but definitely cannot be used as is for vectors.

Please tell me what you think about it.

JM