### PR TITLE
call [super init...] in MaplyVectorTileStyleLine

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileLineStyle.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileLineStyle.mm
@@ -33,6 +33,8 @@
 
 - (instancetype)initWithStyleEntry:(NSDictionary *)style settings:(MaplyVectorStyleSettings *)settings viewC:(MaplyBaseViewController *)viewC
 {
+    self = [super initWithStyleEntry:style viewC:viewC];
+
     subStyles = [NSMutableArray array];
     NSArray *subStylesArray = style[@"substyles"];
     wideVecs.resize([subStylesArray count],false);


### PR DESCRIPTION
MaplyVectorTileLineStyle was not calling `[super initWithStyleEntry:style viewC:viewC]` so self.viewC was never getting set, so `[self resolveVisibility:styleEntry settings:settings desc:desc]` was setting minvis=0 and maxvis=0 if `minscaledenom` or `maxscaledenom` was set.