### PR TITLE
Use Cohen–Sutherland algorithm in ClipLoopToMbr when clipping a line

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobeLib/src/GridClipper.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/src/GridClipper.mm
@@ -26,53 +26,138 @@ namespace WhirlyKit
     
 using namespace ClipperLib;
 
-static float PolyScale = 1e14;
+static float PolyScale = 1e17;
+    typedef int OutCode;
+    
+const int INSIDE = 0; // 0000
+const int LEFT = 1;   // 0001
+const int RIGHT = 2;  // 0010
+const int BOTTOM = 4; // 0100
+const int TOP = 8;    // 1000
 
+OutCode ComputeOutCode(double x, double y, const Mbr &mbr)
+{
+    OutCode code = INSIDE;
+    
+    if (x < mbr.ll().x())
+        code |= LEFT;
+    else if (x > mbr.ur().x())
+        code |= RIGHT;
+    if (y < mbr.ll().y())
+        code |= BOTTOM;
+    else if (y > mbr.ur().y())
+        code |= TOP;
+    
+    return code;
+}
+
+    
 // Clip the given loop to the given MBR
 bool ClipLoopToMbr(const VectorRing &ring,const Mbr &mbr, bool closed,std::vector<VectorRing> &rets)
 {
-    Path subject(ring.size());
-    for (unsigned int ii=0;ii<ring.size();ii++)
-    {
-        const Point2f &pt = ring[ii];
-        subject[ii] = IntPoint(pt.x()*PolyScale,pt.y()*PolyScale);
-    }
-    Path clip(4);
-    clip[0] = IntPoint(mbr.ll().x()*PolyScale,mbr.ll().y()*PolyScale);
-    clip[1] = IntPoint(mbr.ur().x()*PolyScale,mbr.ll().y()*PolyScale);
-    clip[2] = IntPoint(mbr.ur().x()*PolyScale,mbr.ur().y()*PolyScale);
-    clip[3] = IntPoint(mbr.ll().x()*PolyScale,mbr.ur().y()*PolyScale);
-    
-    Clipper c;
-    c.AddPath(subject, ptSubject, closed);
-    c.AddPath(clip, ptClip, true);
-    Paths solution;
-  
     if(!closed)
     {
-        PolyTree polyTreeSolution = *new PolyTree();
-        c.Execute(ctIntersection, polyTreeSolution, pftEvenOdd, pftEvenOdd);
-        PolyTreeToPaths(polyTreeSolution, solution);
+        VectorRing outRing;
+        for (unsigned int ii=1;ii<ring.size();ii++)
+        {
+            Point2f p0 = ring[ii - 1];
+            Point2f p1 = ring[ii];
+            OutCode outcode0 = ComputeOutCode(p0.x(), p0.y(), mbr);
+            OutCode outcode1 = ComputeOutCode(p1.x(), p1.y(), mbr);
+            bool accept = false;
+            
+            while (true) {
+                if (!(outcode0 | outcode1)) { // Both points in MBR
+                    accept = true;
+                    break;
+                } else if (outcode0 & outcode1) { // Both points outside of MBR
+                    break;
+                } else { //At least one point outside of MBR
+                    double x, y;
+                    
+                    // At least one endpoint is outside the clip rectangle; pick it.
+                    OutCode outcodeOut = outcode0 ? outcode0 : outcode1;
+                    
+                    // Now find the intersection point;
+                    // use formulas y = p0.y() + slope * (x - p0.x()), x = p0.x() + (1 / slope) * (y - p0.y())
+                    if (outcodeOut & TOP) {           // point is above the clip rectangle
+                        x = p0.x() + (p1.x() - p0.x()) * (mbr.ur().y() - p0.y()) / (p1.y() - p0.y());
+                        y = mbr.ur().y();
+                    } else if (outcodeOut & BOTTOM) { // point is below the clip rectangle
+                        x = p0.x() + (p1.x() - p0.x()) * (mbr.ll().y() - p0.y()) / (p1.y() - p0.y());
+                        y = mbr.ll().y();
+                    } else if (outcodeOut & RIGHT) {  // point is to the right of clip rectangle
+                        y = p0.y() + (p1.y() - p0.y()) * (mbr.ur().x() - p0.x()) / (p1.x() - p0.x());
+                        x = mbr.ur().x();
+                    } else if (outcodeOut & LEFT) {   // point is to the left of clip rectangle
+                        y = p0.y() + (p1.y() - p0.y()) * (mbr.ll().x() - p0.x()) / (p1.x() - p0.x());
+                        x = mbr.ll().x();
+                    }
+                    
+                    // Now we move outside point to intersection point to clip
+                    // and get ready for next pass.
+                    if (outcodeOut == outcode0) {
+                        p0.x() = x;
+                        p0.y() = y;
+                        outcode0 = ComputeOutCode(p0.x(), p0.y(), mbr);
+                    } else {
+                        p1.x() = x;
+                        p1.y() = y;
+                        outcode1 = ComputeOutCode(p1.x(), p1.y(), mbr);
+                    }
+                }
+            }
+            if (accept) {
+                if (outRing.size() > 1 && outRing[outRing.size() - 1] != p0)
+                {
+                    rets.push_back(outRing);
+                    outRing = VectorRing();
+                }
+                if(outRing.size() == 0) {
+                    outRing.push_back(p0);
+                }
+                outRing.push_back(p1);
+            }
+        }
+        
+        if (outRing.size() > 1)
+            rets.push_back(outRing);
     } else
     {
+        Path subject(ring.size());
+        for (unsigned int ii=0;ii<ring.size();ii++)
+        {
+            const Point2f &pt = ring[ii];
+            subject[ii] = IntPoint(pt.x()*PolyScale,pt.y()*PolyScale);
+        }
+        Path clip(4);
+        clip[0] = IntPoint(mbr.ll().x()*PolyScale,mbr.ll().y()*PolyScale);
+        clip[1] = IntPoint(mbr.ur().x()*PolyScale,mbr.ll().y()*PolyScale);
+        clip[2] = IntPoint(mbr.ur().x()*PolyScale,mbr.ur().y()*PolyScale);
+        clip[3] = IntPoint(mbr.ll().x()*PolyScale,mbr.ur().y()*PolyScale);
+        
+        Clipper c;
+        c.AddPath(subject, ptSubject, closed);
+        c.AddPath(clip, ptClip, true);
+        Paths solution;
         if (!c.Execute(ctIntersection, solution))
         {
             return false;
         }
-    }
-    
-    for (unsigned int ii=0;ii<solution.size();ii++)
-    {
-        Path &outPoly = solution[ii];
-        VectorRing outRing;
-        for (unsigned jj=0;jj<outPoly.size();jj++)
+        
+        for (unsigned int ii=0;ii<solution.size();ii++)
         {
-            IntPoint &outPt = outPoly[jj];
-            outRing.push_back(Point2f(outPt.X/PolyScale,outPt.Y/PolyScale));
+            Path &outPoly = solution[ii];
+            VectorRing outRing;
+            for (unsigned jj=0;jj<outPoly.size();jj++)
+            {
+                IntPoint &outPt = outPoly[jj];
+                outRing.push_back(Point2f(outPt.X/PolyScale,outPt.Y/PolyScale));
+            }
+            
+            if ((closed && outRing.size() > 2) || (!closed && outRing.size() > 1))
+                rets.push_back(outRing);
         }
-     
-        if ((closed && outRing.size() > 2) || (!closed && outRing.size() > 1))
-            rets.push_back(outRing);
     }
     return true;
 }

--- a/WhirlyGlobeSrc/WhirlyGlobeLib/src/GridClipper.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/src/GridClipper.mm
@@ -57,6 +57,8 @@ bool ClipLoopToMbr(const VectorRing &ring,const Mbr &mbr, bool closed,std::vecto
 {
     if(!closed)
     {
+        //Cohen-sutherland algorithm based on example implementation from wikipedia
+        //https://en.wikipedia.org/wiki/Cohen%E2%80%93Sutherland_algorithm#Example_C.2FC.2B.2B_implementation
         VectorRing outRing;
         for (unsigned int ii=1;ii<ring.size();ii++)
         {

--- a/WhirlyGlobeSrc/WhirlyGlobeLib/src/GridClipper.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/src/GridClipper.mm
@@ -26,8 +26,8 @@ namespace WhirlyKit
     
 using namespace ClipperLib;
 
-static float PolyScale = 1e17;
-    typedef int OutCode;
+static float PolyScale = 1e14;
+typedef int OutCode;
     
 const int INSIDE = 0; // 0000
 const int LEFT = 1;   // 0001

--- a/WhirlyGlobeSrc/WhirlyGlobeLib/src/GridClipper.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/src/GridClipper.mm
@@ -155,7 +155,7 @@ bool ClipLoopToMbr(const VectorRing &ring,const Mbr &mbr, bool closed,std::vecto
                 outRing.push_back(Point2f(outPt.X/PolyScale,outPt.Y/PolyScale));
             }
             
-            if ((closed && outRing.size() > 2) || (!closed && outRing.size() > 1))
+            if (outRing.size() > 2)
                 rets.push_back(outRing);
         }
     }


### PR DESCRIPTION
Clipping open paths in clipper has several bugs, and sometimes crashes, and it doesn't seem like it will ever get fixed. As an alternative I've added an implementation of the Cohen–Sutherland line clipping algorithm, but it is only used when clipping an open path, not a closed path.

Fixes #559 