### PR TITLE
Fix WhirlyGlobe issue 621 : longpress triggers when zooming

### DIFF
--- a/WhirlyGlobeSrc/Android/src/com/mousebird/maply/GlobeGestureHandler.java
+++ b/WhirlyGlobeSrc/Android/src/com/mousebird/maply/GlobeGestureHandler.java
@@ -185,11 +185,6 @@ public class GlobeGestureHandler
 			return true;
 		}
 
-        @Override
-        public boolean onSingleTapUp(MotionEvent e)
-        {
-            return true;
-        }
 
 		@Override
 		public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX,
@@ -310,13 +305,21 @@ public class GlobeGestureHandler
 		public void onLongPress(MotionEvent e) 
 		{
 //			Log.d("Maply","Long Press");
-			globeControl.processLongPress(new Point2d(e.getX(),e.getY()));
+			if (e.getPointerCount() == 1)
+				globeControl.processLongPress(new Point2d(e.getX(),e.getY()));
 		}
 
 		@Override
 		public void onShowPress(MotionEvent e) 
 		{
 //			Log.d("Maply","ShowPress");
+		}
+
+
+		@Override
+		public boolean onSingleTapUp(MotionEvent e)
+		{
+			return true;
 		}
 
 		@Override

--- a/WhirlyGlobeSrc/Android/src/com/mousebird/maply/MapGestureHandler.java
+++ b/WhirlyGlobeSrc/Android/src/com/mousebird/maply/MapGestureHandler.java
@@ -265,7 +265,8 @@ public class MapGestureHandler
 		public void onLongPress(MotionEvent e) 
 		{
 //			Log.d("Maply","Long Press");
-			mapControl.processLongPress(new Point2d(e.getX(),e.getY()));
+			if (!sl.isActive && gl.isActive && e.getPointerCount() == 1)
+				mapControl.processLongPress(new Point2d(e.getX(),e.getY()));
 		}
 
 


### PR DESCRIPTION
This is the fix for issue #621 .
I am not entirely happy the way I had to fix it for the map, but for some reason, it does not behave as on the globe (motoinEvent.getPointerCount is always 1 on the map).
