### PR TITLE
Reproducing issue #622 areal color are darker in vector tiles

### DIFF
--- a/WhirlyGlobeSrc/Android/src/com/mousebird/maply/VectorStyleSimpleGenerator.java
+++ b/WhirlyGlobeSrc/Android/src/com/mousebird/maply/VectorStyleSimpleGenerator.java
@@ -148,8 +148,23 @@ public class VectorStyleSimpleGenerator implements VectorStyleInterface
             vecInfo.setEnable(false);
 
             ComponentObject compObj = controller.addVectors(vecObjs,vecInfo,threadMode);
-            if (compObj != null)
-                return new ComponentObject[]{compObj};
+//            if (compObj != null)
+//                return new ComponentObject[]{compObj};
+
+            //TODO this only to reproduce issue #622 https://github.com/mousebird/WhirlyGlobe/issues/622
+            // Shall be removed once the issue is dealt with
+            VectorInfo outlineVectorInfo = new VectorInfo();
+            outlineVectorInfo.setColor((float)red,(float)green,(float)blue,1.f); // Same color
+            outlineVectorInfo.setLineWidth(5);
+            outlineVectorInfo.setFilled(false);
+            outlineVectorInfo.setDrawPriority(drawPriority + 1);
+            outlineVectorInfo.setEnable(false);
+
+            ComponentObject outlineCompObj = controller.addVectors(vecObjs, outlineVectorInfo, threadMode);
+
+            if (compObj != null && outlineCompObj != null)
+                return new ComponentObject[]{compObj, outlineCompObj};
+
             return null;
         }
     }

--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/GestureFeedbackTestCase.java
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/GestureFeedbackTestCase.java
@@ -17,7 +17,64 @@ import com.mousebirdconsulting.autotester.Framework.MaplyTestCase;
 /**
  * Created by sjg on 1/27/16.
  */
-public class GestureFeedbackTestCase extends MaplyTestCase implements GlobeController.GestureDelegate {
+public class GestureFeedbackTestCase extends MaplyTestCase {
+
+
+    private GlobeController.GestureDelegate globeGestureDelegate = new GlobeController.GestureDelegate() {
+
+        @Override
+        public void userDidSelect(GlobeController globeVC, SelectedObject[] objs, Point2d loc, Point2d screenLoc) {
+            Log.i("AutoTester","User selected feature at" + loc.getX() + " " + loc.getY());
+        }
+
+        @Override
+        public void userDidTap(GlobeController globeVC, Point2d loc, Point2d screenLoc) {
+            Log.i("AutoTester","User tapped at " + loc.getX() + " " + loc.getY());
+        }
+
+        @Override
+        public void userDidLongPress(GlobeController globeController, Object o, Point2d loc, Point2d screenLoc) {
+            Log.i("AutoTester","User long pressed at " + loc.getX() + " " + loc.getY());
+        }
+
+        @Override
+        public void globeDidStartMoving(GlobeController globeVC, boolean userMotion) {
+            Log.i("AutoTester",String.format("Globe did start moving (userMotion = %b)", userMotion));
+        }
+
+        // Called for every frame
+        @Override
+        public void globeDidMove(GlobeController globeVC, Point3d[] corners, boolean userMotion) {
+            updateBbox(globeVC,corners);
+            Log.i("AutoTester",String.format("Globe did move (userMotion = %b)", userMotion));
+        }
+
+        @Override
+        public void globeDidStopMoving(GlobeController globeVC, Point3d[] corners, boolean userMotion) {
+            updateBbox(globeVC,corners);
+            Log.i("AutoTester",String.format("Globe did stop moving (userMotion = %b)", userMotion));
+        }
+    };
+
+
+    private MapController.GestureDelegate mapGestureDelegate = new MapController.GestureDelegate() {
+        @Override
+        public void userDidSelect(MapController mapController, SelectedObject[] selectedObjects, Point2d loc, Point2d screenloc) {
+            Log.i("AutoTester","User selected feature at" + loc.getX() + " " + loc.getY());
+        }
+
+        @Override
+        public void userDidTap(MapController mapController, Point2d loc, Point2d screenloc) {
+            Log.i("AutoTester","User tapped at " + loc.getX() + " " + loc.getY());
+        }
+
+        @Override
+        public void userDidLongPress(MapController mapController, Object o, Point2d loc, Point2d screenloc) {
+            Log.i("AutoTester","User long pressed at " + loc.getX() + " " + loc.getY());
+        }
+    };
+
+
     public GestureFeedbackTestCase(Activity activity) {
         super(activity);
         setTestName("Gesture Feedback Test");
@@ -29,7 +86,7 @@ public class GestureFeedbackTestCase extends MaplyTestCase implements GlobeContr
     public boolean setUpWithGlobe(GlobeController globeVC) throws Exception {
         CartoDBMapTestCase mapBoxSatelliteTestCase = new CartoDBMapTestCase(this.getActivity());
         mapBoxSatelliteTestCase.setUpWithGlobe(globeVC);
-        globeVC.gestureDelegate = this;
+        globeVC.gestureDelegate = globeGestureDelegate;
         return true;
     }
 
@@ -37,39 +94,11 @@ public class GestureFeedbackTestCase extends MaplyTestCase implements GlobeContr
     public boolean setUpWithMap(MapController mapVC) throws Exception {
         CartoDBMapTestCase mapBoxSatelliteTestCase = new CartoDBMapTestCase(this.getActivity());
         mapBoxSatelliteTestCase.setUpWithMap(mapVC);
+        mapVC.gestureDelegate = mapGestureDelegate;
         return true;
     }
 
-    @Override
-    public void userDidSelect(GlobeController globeVC, SelectedObject[] objs, Point2d loc, Point2d screenLoc) {
-        Log.i("AutoTester","User selected feature at");
-    }
 
-    @Override
-    public void userDidTap(GlobeController globeVC, Point2d loc, Point2d screenLoc) {
-        Log.i("AutoTester","User tapped at " + loc.getX() + " " + loc.getY());
-    }
-
-    @Override
-    public void userDidLongPress(GlobeController globeController, Object o, Point2d loc, Point2d screenLoc) {
-        Log.i("AutoTester","User long pressed at " + loc.getX() + " " + loc.getY());
-    }
-
-    @Override
-    public void globeDidStartMoving(GlobeController globeVC, boolean b) {
-        Log.i("AutoTester","User did start moving");
-    }
-
-    @Override
-    public void globeDidStopMoving(GlobeController globeVC, Point3d[] corners, boolean userMotion) {
-        updateBbox(globeVC,corners);
-    }
-
-    // Called for every frame
-    @Override
-    public void globeDidMove(GlobeController globeVC, Point3d[] corners, boolean userMotion) {
-        updateBbox(globeVC,corners);
-    }
 
     VectorInfo vecInfo = null;
     ComponentObject compObj = null;

--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/LocalVectorTileTestCase.java
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/LocalVectorTileTestCase.java
@@ -45,7 +45,7 @@ public class LocalVectorTileTestCase extends MaplyTestCase {
     {
 
         // We need to copy the file from the asset so that it can be used as a file
-        File mbTiles = this.getMbTileFile("mbtiles/world_full_v2.mbtiles", "world_full_v2.mbtiles");
+        File mbTiles = this.getMbTileFile("mbtiles/world_0_6.mbtiles", "world_0_6.mbtiles");
 
         if (!mbTiles.exists()) {
             throw new FileNotFoundException(String.format("Could not copy MBTiles asset to \"%s\"", mbTiles.getAbsolutePath()));


### PR DESCRIPTION
This is just to reproduce the problem descrided in issue #622 .

An outline has been added to areals in VectorStyleSimpleGenerator.
It is the same color as the inside and therefore should not be visible. It is.

Note: this issue exhibits on the map only, there is a color difference on the globe that varies depending on lighting. Lighting applies to areas not linears.