### PR TITLE
Reproducing WG issue #644.

### DIFF
--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/ColorfulStyleGenerator.java
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/ColorfulStyleGenerator.java
@@ -1,0 +1,187 @@
+package com.mousebirdconsulting.autotester;
+
+import android.graphics.Color;
+
+import com.mousebird.maply.AttrDictionary;
+import com.mousebird.maply.ComponentObject;
+import com.mousebird.maply.MaplyBaseController;
+import com.mousebird.maply.MaplyTileID;
+import com.mousebird.maply.VectorInfo;
+import com.mousebird.maply.VectorObject;
+import com.mousebird.maply.VectorStyle;
+import com.mousebird.maply.VectorStyleInterface;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Project AutoTesterAndroid
+ * Created by jmc on 06/07/16.
+ */
+public class ColorfulStyleGenerator implements VectorStyleInterface {
+
+
+    //***********************************************************************//
+    //                           Inner classes                               //
+    //***********************************************************************//
+
+    public abstract class ColorfulSimpleStyle implements VectorStyle {
+
+        protected String uuid;
+
+        @Override
+        public String getUuid() {
+
+            if (uuid == null) {
+                uuid = "#" + Math.random() * 1000000.0D + Math.random() * 10000.0D;
+            }
+
+            return uuid;
+        }
+    }
+
+    public class ColorfulSimpleVectors extends ColorfulSimpleStyle {
+
+        private int priority;
+        private int color;
+
+        public ColorfulSimpleVectors(int priority) {
+            this.priority = priority;
+            int r = (int) (255 * (Math.random() / 2.0D + 0.5D));
+            int g = (int) (255 * (Math.random() / 2.0D + 0.5D));
+            int b = (int) (255 * (Math.random() / 2.0D + 0.5D));
+
+            color = Color.rgb(r, g, b);
+        }
+
+
+        @Override
+        public boolean geomIsAdditive() {
+            return false;
+        }
+
+
+        @Override
+        public ComponentObject[] buildObjects(List<VectorObject> vectors, MaplyTileID maplyTileID, MaplyBaseController controller) {
+
+            VectorInfo vecInfo = new VectorInfo();
+            vecInfo.setColor(color);
+            vecInfo.setLineWidth(4.0F);
+            vecInfo.setFilled(false);
+            vecInfo.setDrawPriority(priority);
+            vecInfo.setEnable(false);
+            ComponentObject compObj = controller.addVectors(vectors, vecInfo, MaplyBaseController.ThreadMode.ThreadCurrent);
+
+            return compObj != null ? new ComponentObject[]{compObj} : null;
+        }
+    }
+
+
+    public class ColorfulSimpleAreals extends ColorfulSimpleStyle {
+
+        private int priority;
+
+        public ColorfulSimpleAreals(int priority) {
+            this.priority = priority;
+        }
+
+
+        @Override
+        public boolean geomIsAdditive() {
+            return false;
+        }
+
+        @Override
+        public ComponentObject[] buildObjects(List<VectorObject> vectors, MaplyTileID maplyTileID, MaplyBaseController controller) {
+            VectorInfo vecInfo = new VectorInfo();
+            vecInfo.setColor(AREAL_COLORS[maplyTileID.level]);
+            vecInfo.setFilled(true);
+            vecInfo.setDrawPriority(priority);
+            vecInfo.setEnable(false);
+            ComponentObject compObj = controller.addVectors(vectors, vecInfo, MaplyBaseController.ThreadMode.ThreadCurrent);
+
+            return compObj != null ? new ComponentObject[]{compObj} : null;
+        }
+    }
+
+
+    //***********************************************************************//
+    //                          Class variables                              //
+    //***********************************************************************//
+
+    private static int AREAL_COLORS[] = {Color.WHITE, Color.LTGRAY, Color.GRAY, Color.DKGRAY, Color.GREEN, Color.BLUE, Color.CYAN, Color.MAGENTA, Color.BLACK};
+
+
+    //***********************************************************************//
+    //                         Instance variables                            //
+    //***********************************************************************//
+
+    private Map<String, VectorStyle> stylesByUuid = new HashMap<>();
+    private Map<String, VectorStyle> stylesByLayerName = new HashMap<>();
+
+
+    //***********************************************************************//
+    //                            Constructors                               //
+    //***********************************************************************//
+
+
+    //***********************************************************************//
+    //                         Getters and setters                           //
+    //***********************************************************************//
+
+
+    //***********************************************************************//
+    //                               Interfaces                              //
+    //***********************************************************************//
+
+    /* Implements VectorStyleInterface */
+
+    @Override
+    public VectorStyle[] stylesForFeature(AttrDictionary attrs, MaplyTileID maplyTileID, String layer, MaplyBaseController maplyBaseController) {
+
+        VectorStyle style;
+        if ((style = stylesByLayerName.get(layer)) != null) {
+            return new VectorStyle[]{style};
+        }
+
+        style = new ColorfulSimpleAreals(900);
+        int geomType = attrs.getInt("geometry_type").intValue();
+
+        if (geomType == 2) {
+            style = new ColorfulSimpleVectors(1000);
+        }
+
+        stylesByUuid.put(style.getUuid(), style);
+        stylesByLayerName.put(layer, style);
+
+        return new VectorStyle[]{style};
+    }
+
+    @Override
+    public boolean layerShouldDisplay(String s, MaplyTileID maplyTileID) {
+        return false;
+    }
+
+    @Override
+    public VectorStyle styleForUUID(String s, MaplyBaseController maplyBaseController) {
+        return stylesByUuid.get(s);
+    }
+
+
+    //***********************************************************************//
+    //                               Overrides                               //
+    //***********************************************************************//
+
+
+    //***********************************************************************//
+    //                           Public methods                              //
+    //***********************************************************************//
+
+
+    //***********************************************************************//
+    //                           Private methods                             //
+    //***********************************************************************//
+
+
+}

--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/LocalVectorTileTestCase.java
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/LocalVectorTileTestCase.java
@@ -12,7 +12,7 @@ import com.mousebird.maply.MapboxVectorTileSource;
 import com.mousebird.maply.MaplyBaseController;
 import com.mousebird.maply.Point2d;
 import com.mousebird.maply.QuadPagingLayer;
-import com.mousebird.maply.VectorStyleSimpleGenerator;
+import com.mousebirdconsulting.autotester.ColorfulStyleGenerator;
 import com.mousebirdconsulting.autotester.ConfigOptions;
 import com.mousebirdconsulting.autotester.Framework.MaplyTestCase;
 
@@ -45,7 +45,7 @@ public class LocalVectorTileTestCase extends MaplyTestCase {
     {
 
         // We need to copy the file from the asset so that it can be used as a file
-        File mbTiles = this.getMbTileFile("mbtiles/world_full_v2.mbtiles", "world_full_v2.mbtiles");
+        File mbTiles = this.getMbTileFile("mbtiles/world_0_8.mbtiles", "world_0_8.mbtiles");
 
         if (!mbTiles.exists()) {
             throw new FileNotFoundException(String.format("Could not copy MBTiles asset to \"%s\"", mbTiles.getAbsolutePath()));
@@ -54,12 +54,15 @@ public class LocalVectorTileTestCase extends MaplyTestCase {
         Log.d(TAG, String.format("Obtained MBTiles SQLLite database \"%s\"", mbTiles.getAbsolutePath()));
 
         MBTiles mbTileSource = new MBTiles(mbTiles);
-        VectorStyleSimpleGenerator simpleStyles = new VectorStyleSimpleGenerator(baseController);
+        ColorfulStyleGenerator simpleStyles = new ColorfulStyleGenerator();
         MapboxVectorTileSource tileSource = new MapboxVectorTileSource(mbTileSource,simpleStyles);
 
         QuadPagingLayer layer = new QuadPagingLayer(baseController,tileSource.coordSys,tileSource);
         layer.setSimultaneousFetches(4);
         layer.setImportance(1024*1024);
+
+//        layer.setSingleLevelLoading(baseController instanceof MapController);
+//        layer.setUseTargetZoomLevel(baseController instanceof MapController);
 
         return layer;
     }
@@ -70,8 +73,8 @@ public class LocalVectorTileTestCase extends MaplyTestCase {
         baseCase.setUpWithGlobe(globeVC);
         globeVC.addLayer(setupVectorLayer(globeVC, ConfigOptions.TestType.GlobeTest));
 
-        Point2d loc = Point2d.FromDegrees(2.3508, 48.8567);
-        globeVC.setPositionGeo(loc.getX(),loc.getY(),0.15);
+        Point2d loc = Point2d.FromDegrees(-1.1219586761346174,46.221563509822936);
+        globeVC.setPositionGeo(loc.getX(),loc.getY(),1.2);
 
         return true;
     }
@@ -82,8 +85,8 @@ public class LocalVectorTileTestCase extends MaplyTestCase {
         baseCase.setUpWithMap(mapVC);
         mapVC.addLayer(setupVectorLayer(mapVC, ConfigOptions.TestType.MapTest));
 
-        Point2d loc = Point2d.FromDegrees(2.3508, 48.8567);
-        mapVC.setPositionGeo(loc.getX(),loc.getY(),0.15);
+        Point2d loc = Point2d.FromDegrees(-1.1219586761346174,46.221563509822936);
+        mapVC.setPositionGeo(loc.getX(),loc.getY(),1.2);
 
         return true;
     }


### PR DESCRIPTION
Steve, this is soem material to reproduce #644 .

This is just to reproduce it, there is northing interesting that should be merged in the kit.

I have hacked the LocalVectorTestCase and added a simple style that color areal based on zoom level.

You will need world_0_8.mbtiles that I have shared with you.

You need to zoom to the area highlighted in the image.
Once you pass the last level in the vector file (8) that shows in black, you see light gray polygons again (level 1).

*Breaking news* while covering the last mile, I noticed that this does not happen when setting singleLevelLoading to true.

![screenshot_20160706-165349](https://cloud.githubusercontent.com/assets/2640502/16622863/eda423e2-439b-11e6-8e5f-2e94cca3ce88.png)
