### PR TITLE
Long press fixes

### DIFF
--- a/WhirlyGlobeSrc/Android/src/com/mousebird/maply/GlobeController.java
+++ b/WhirlyGlobeSrc/Android/src/com/mousebird/maply/GlobeController.java
@@ -428,11 +428,11 @@ public class GlobeController extends MaplyBaseController implements View.OnTouch
 		/**
 		 * The user did long press somewhere, there might be an object
 		 * @param globeControl The maply controller this is associated with.
-		 * @param selObj The object the user selected (e.g. MaplyScreenMarker) or null if there was no object.
+		 * @param selObjs The objects the user selected (e.g. MaplyScreenMarker) or null if there was no object.
 		 * @param loc The location they tapped on.  This is in radians.  If null, then the user tapped outside the globe.
          * @param screenLoc The location on the OpenGL surface.
          */
-        public void userDidLongPress(GlobeController globeControl, Object selObj, Point2d loc, Point2d screenLoc);
+        public void userDidLongPress(GlobeController globeControl, SelectedObject selObjs[], Point2d loc, Point2d screenLoc);
 
         /**
          * Called when the globe first starts moving.
@@ -506,11 +506,15 @@ public class GlobeController extends MaplyBaseController implements View.OnTouch
 		Point3d loc = globeView.pointOnSphereFromScreen(screenLoc, globeTransform, renderWrapper.maplyRender.frameSize, false);
 		if (loc == null)
 			return;
+		Point3d localPt = globeView.getCoordAdapter().displayToLocal(loc);
+		Point3d geoPt = null;
+		if (localPt != null)
+			geoPt = globeView.getCoordAdapter().getCoordSystem().localToGeographic(localPt);
 
 		if (gestureDelegate != null)
 		{
-			Object selObj = this.getObjectAtScreenLoc(screenLoc);
-			gestureDelegate.userDidLongPress(this, selObj, loc.toPoint2d(), screenLoc);
+			SelectedObject selObjs[] = this.getObjectsAtScreenLoc(screenLoc);
+			gestureDelegate.userDidLongPress(this, selObjs, geoPt.toPoint2d(), screenLoc);
 
 		}
 

--- a/WhirlyGlobeSrc/Android/src/com/mousebird/maply/MapController.java
+++ b/WhirlyGlobeSrc/Android/src/com/mousebird/maply/MapController.java
@@ -476,11 +476,11 @@ public class MapController extends MaplyBaseController implements View.OnTouchLi
 		/**
 		 * The user long pressed somewhere, either on a selectable object or nor
 		 * @param mapController The maply controller this is associated with.
-		 * @param selObj The object (e.g. MaplyScreenMarker) that the user long pressed or null if there was none
+		 * @param selObjs The objects (e.g. MaplyScreenMarker) that the user long pressed or null if there was none
 		 * @param loc The location they tapped on.  This is in radians.
          * @param screenLoc The location on the OpenGL surface.
          */
-		public void userDidLongPress(MapController mapController, Object selObj, Point2d loc, Point2d screenLoc);
+		public void userDidLongPress(MapController mapController, SelectedObject[] selObjs, Point2d loc, Point2d screenLoc);
 
 		/**
 		 * Called when the map first starts moving.
@@ -553,9 +553,15 @@ public class MapController extends MaplyBaseController implements View.OnTouchLi
 
 		if (gestureDelegate != null)
 		{
-			Object selObj = this.getObjectAtScreenLoc(screenLoc);
-			gestureDelegate.userDidLongPress(this, selObj, loc.toPoint2d(), screenLoc);
+			Point3d localPt = mapView.getCoordAdapter().displayToLocal(loc);
+			Point3d geoPt = null;
+			if (localPt != null)
+				geoPt = mapView.getCoordAdapter().getCoordSystem().localToGeographic(localPt);
 
+//			Object selObj = this.getObjectAtScreenLoc(screenLoc);
+			SelectedObject selObjs[] = this.getObjectsAtScreenLoc(screenLoc);
+
+			gestureDelegate.userDidLongPress(this, selObjs, geoPt.toPoint2d(), screenLoc);
 		}
 
 	}

--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/Framework/MaplyTestCase.java
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/Framework/MaplyTestCase.java
@@ -337,7 +337,7 @@ public class MaplyTestCase extends AsyncTask<Void, View, Void> implements GlobeC
 			Log.d("Maply","User is looking at bounding box: " + mbr);
 	}
 
-	public void userDidLongPress(GlobeController globeControl, Object selObj, Point2d loc, Point2d screenLoc)
+	public void userDidLongPress(GlobeController globeControl, SelectedObject[] selObjs, Point2d loc, Point2d screenLoc)
 	{}
 
 	public void globeDidStartMoving(GlobeController globeControl, boolean userMotion)
@@ -375,6 +375,6 @@ public class MaplyTestCase extends AsyncTask<Void, View, Void> implements GlobeC
 		Point2d newGeo = mapControl.geoPointFromScreen(newScreenPt);
 	}
 
-	public void userDidLongPress(MapController mapController, Object selObj, Point2d loc, Point2d screenLoc)
+	public void userDidLongPress(MapController mapController, SelectedObject[] selObjs, Point2d loc, Point2d screenLoc)
 	{}
 }

--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/GestureFeedbackTestCase.java
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/GestureFeedbackTestCase.java
@@ -33,7 +33,7 @@ public class GestureFeedbackTestCase extends MaplyTestCase {
         }
 
         @Override
-        public void userDidLongPress(GlobeController globeController, Object o, Point2d loc, Point2d screenLoc) {
+        public void userDidLongPress(GlobeController globeController, SelectedObject[] selObjs, Point2d loc, Point2d screenLoc) {
             Log.i("AutoTester","User long pressed at " + loc.getX() + " " + loc.getY());
         }
 
@@ -70,7 +70,7 @@ public class GestureFeedbackTestCase extends MaplyTestCase {
         }
 
         @Override
-        public void userDidLongPress(MapController mapController, Object o, Point2d loc, Point2d screenloc) {
+        public void userDidLongPress(MapController mapController, SelectedObject[] selObjs, Point2d loc, Point2d screenloc) {
             Log.i("AutoTester","User long pressed at " + loc.getX() + " " + loc.getY());
         }
 

--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/MBTilesImageTestCase.java
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/MBTilesImageTestCase.java
@@ -50,7 +50,7 @@ public class MBTilesImageTestCase extends MaplyTestCase {
         }
 
         @Override
-        public void userDidLongPress(GlobeController globeController, Object o, Point2d loc, Point2d screenLoc) {
+        public void userDidLongPress(GlobeController globeController, SelectedObject[] selObjs, Point2d loc, Point2d screenLoc) {
             // Intentionally blank
         }
 


### PR DESCRIPTION
This is to align the MapDelegate.userDidLongPress method onto the userDidSelect method (using an array of SelectedObject rather that a single object)