### PR TITLE
*DO NOT MERGE* Trying to make label selectable. Not working yet

### DIFF
--- a/WhirlyGlobeSrc/Android/src/com/mousebird/maply/MaplyBaseController.java
+++ b/WhirlyGlobeSrc/Android/src/com/mousebird/maply/MaplyBaseController.java
@@ -1088,6 +1088,7 @@ public class MaplyBaseController
 	{
 		synchronized(selectionMap)
 		{
+			Log.v("Maply", "Adding selectable object " + selObj.getClass().getSimpleName() + " #" + Long.toString(selectID));
 			compObj.addSelectID(selectID);
 			selectionMap.put(selectID,selObj);
 		}
@@ -1116,6 +1117,9 @@ public class MaplyBaseController
 			synchronized(selectionMap) {
 				for (SelectedObject selObj : objs) {
 					long selectID = selObj.getSelectID();
+
+					Log.v("Maply", "Got selectedObjects on screenLoc #" + Long.toString(selectID));
+
 					selObj.selObj = selectionMap.get(selectID);
 				}
 			}
@@ -1192,6 +1196,12 @@ public class MaplyBaseController
 				{
 					InternalLabel intLabel = new InternalLabel(label,labelInfo);
 					intLabels.add(intLabel);
+
+					// Keep track of this one for selection
+					if (label.selectable)
+					{
+						addSelectableObject(label.ident,label,compObj);
+					}
 				}
 
 				long labelId = EmptyIdentity;

--- a/WhirlyGlobeSrc/Android/src/com/mousebird/maply/ScreenLabel.java
+++ b/WhirlyGlobeSrc/Android/src/com/mousebird/maply/ScreenLabel.java
@@ -31,6 +31,12 @@ package com.mousebird.maply;
  */
 public class ScreenLabel 
 {
+
+	/**
+	 * Unique ID used by Maply for selection.
+	 */
+	long ident = Identifiable.genID();
+
 	/**
 	 * The location in geographic (WGS84) radians.  x is longitude, y is latitude.
 	 * The label will track this location.

--- a/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/ScreenLabelsTestCase.java
+++ b/WhirlyGlobeSrc/AutoTesterAndroid/app/src/main/java/com/mousebirdconsulting/autotester/TestCases/ScreenLabelsTestCase.java
@@ -3,6 +3,7 @@ package com.mousebirdconsulting.autotester.TestCases;
 import android.app.Activity;
 import android.graphics.Color;
 import android.graphics.Typeface;
+import android.util.Log;
 
 import com.mousebird.maply.AttrDictionary;
 import com.mousebird.maply.ComponentObject;
@@ -12,8 +13,10 @@ import com.mousebird.maply.MapController;
 import com.mousebird.maply.MaplyBaseController;
 import com.mousebird.maply.MarkerInfo;
 import com.mousebird.maply.Point2d;
+import com.mousebird.maply.Point3d;
 import com.mousebird.maply.ScreenLabel;
 import com.mousebird.maply.ScreenMarker;
+import com.mousebird.maply.SelectedObject;
 import com.mousebird.maply.VectorObject;
 import com.mousebirdconsulting.autotester.Framework.MaplyTestCase;
 
@@ -48,6 +51,54 @@ public class ScreenLabelsTestCase extends MaplyTestCase {
 		insertLabels(baseView.getVectors(), mapVC);
 		Point2d loc = Point2d.FromDegrees(-74.075833, 4.598056);
 		mapVC.setPositionGeo(loc.getX(), loc.getY(), 3);
+
+		mapVC.gestureDelegate = new MapController.GestureDelegate() {
+			@Override
+			public void userDidSelect(MapController mapController, SelectedObject[] selectedObjects, Point2d point2d, Point2d point2d1) {
+
+				Log.v("Maply", "User did select");
+
+				if (selectedObjects == null) {
+					return;
+				}
+
+				for (SelectedObject selectedObject : selectedObjects) {
+
+					if (selectedObject.selObj != null) {
+
+						Log.v("Maply", "User selected a " + selectedObject.selObj.getClass().getSimpleName());
+
+					}
+
+				}
+
+			}
+
+			@Override
+			public void userDidTap(MapController mapController, Point2d point2d, Point2d point2d1) {
+				Log.v("Maply", "User did tap");
+			}
+
+			@Override
+			public void userDidLongPress(MapController mapController, Object o, Point2d point2d, Point2d point2d1) {
+				Log.v("Maply", "User did long press");
+			}
+
+			@Override
+			public void mapDidStartMoving(MapController mapController, boolean b) {
+
+			}
+
+			@Override
+			public void mapDidStopMoving(MapController mapController, Point3d[] point3ds, boolean b) {
+
+			}
+
+			@Override
+			public void mapDidMove(MapController mapController, Point3d[] point3ds, boolean b) {
+
+			}
+		};
 		return true;
 	}
 
@@ -94,6 +145,9 @@ public class ScreenLabelsTestCase extends MaplyTestCase {
 					label.text = labelName;
 					label.loc = object.centroid();
 					labels.add(label);
+
+					label.selectable = true;
+					label.userObject = labelName;
 
 					if (addMarkers) {
 						ScreenMarker marker = new ScreenMarker();


### PR DESCRIPTION
Steve,
I am trying to make selectable labels, and though it looked easy at the beginning, it does not work.

I followed what was done with markers, but it does not work.
- I added an ìdent` field to ScreenLabel
- When adding a ScreenLabel that is selectable I call `addSelectableObject` on the Controller

I thought it would work from that, but it ain't.

What I see in the logs (I have added a few) is that the ID that is coming back from `getSelectID()` (BaseController line 1091) has nothing to do with the ID that where added.

Then the object is not found in the selection map, then selectedObject.selObject remains null).

You can test it on the map in the ScreenLabelTestCase.

If you can put me back on track I think I can make it work, I'll cleanse the code and resubmit a PR.

Many thanks,
JM
