### PR TITLE
Interaction with the environment is lost after resizing one of the views.

### DIFF
--- a/WhirlyGlobeSrc/AutoTester/AutoTester.xcodeproj/project.pbxproj
+++ b/WhirlyGlobeSrc/AutoTester/AutoTester.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		2BE53AF31D258FEE00B60FAD /* libWhirlyGlobeLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BE53AF21D258FEE00B60FAD /* libWhirlyGlobeLib.a */; };
 		2BE53AF41D25901300B60FAD /* WhirlyGlobeMaplyComponent.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BE53AEF1D258FE800B60FAD /* WhirlyGlobeMaplyComponent.framework */; };
 		2BFC7E511D132DCB0040E2A3 /* ScreenMarkersTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BFC7E501D132DCB0040E2A3 /* ScreenMarkersTestCase.m */; };
+		8820852B1DC81051008F8E76 /* Issue721TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8820852A1DC81051008F8E76 /* Issue721TestCase.swift */; };
 		88231C791BA784BC00A95F2B /* ConfigViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 88231C781BA784BC00A95F2B /* ConfigViewController.xib */; };
 		883DF71B1C1CE164000756E9 /* AnimatedBasemapTestCase-globe.png in Resources */ = {isa = PBXBuildFile; fileRef = 883DF6F11C1CE164000756E9 /* AnimatedBasemapTestCase-globe.png */; };
 		883DF71C1C1CE164000756E9 /* AnimatedBasemapTestCase-map.png in Resources */ = {isa = PBXBuildFile; fileRef = 883DF6F21C1CE164000756E9 /* AnimatedBasemapTestCase-map.png */; };
@@ -593,6 +594,7 @@
 		50758EC5237C3DF35AB67BE9 /* Pods-AutoTester.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoTester.release.xcconfig"; path = "Pods/Target Support Files/Pods-AutoTester/Pods-AutoTester.release.xcconfig"; sourceTree = "<group>"; };
 		726309C36257E6205E08B947 /* Pods-AutoTester.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AutoTester.debug.xcconfig"; path = "Pods/Target Support Files/Pods-AutoTester/Pods-AutoTester.debug.xcconfig"; sourceTree = "<group>"; };
 		8810B2D11BA9D45F00446CE3 /* MaplyTesterBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MaplyTesterBridge.h; sourceTree = "<group>"; };
+		8820852A1DC81051008F8E76 /* Issue721TestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Issue721TestCase.swift; sourceTree = "<group>"; };
 		88231C781BA784BC00A95F2B /* ConfigViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ConfigViewController.xib; sourceTree = "<group>"; };
 		883DF6F11C1CE164000756E9 /* AnimatedBasemapTestCase-globe.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AnimatedBasemapTestCase-globe.png"; sourceTree = "<group>"; };
 		883DF6F21C1CE164000756E9 /* AnimatedBasemapTestCase-map.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AnimatedBasemapTestCase-map.png"; sourceTree = "<group>"; };
@@ -1303,6 +1305,7 @@
 				2BBB70821D5E9079009B67A6 /* VectorStyleTestCase.m */,
 				2B2A417C1D83454900098E12 /* ActiveObjectTestCase.h */,
 				2B2A417D1D83454900098E12 /* ActiveObjectTestCase.m */,
+				8820852A1DC81051008F8E76 /* Issue721TestCase.swift */,
 			);
 			path = testCases;
 			sourceTree = "<group>";
@@ -2541,6 +2544,7 @@
 				E5679F491CB72DE800369A15 /* WMSTestCase.m in Sources */,
 				2B93D9671D41433500EAD280 /* WideVectorGlobeTestCase.m in Sources */,
 				D8200C981BE93E6E00B22CF5 /* StarsSunTestCase.swift in Sources */,
+				8820852B1DC81051008F8E76 /* Issue721TestCase.swift in Sources */,
 				D8341A631BE299BF00411A46 /* MapzenVectorTestCase.swift in Sources */,
 				D8F2FE291BE7C2000058A310 /* MarkersTestCase.swift in Sources */,
 				D8F2FE231BE7B1B40058A310 /* MapzenSource.m in Sources */,

--- a/WhirlyGlobeSrc/AutoTester/AutoTester/StartupViewController.swift
+++ b/WhirlyGlobeSrc/AutoTester/AutoTester/StartupViewController.swift
@@ -62,7 +62,9 @@ class StartupViewController: UITableViewController, UIPopoverControllerDelegate 
 		WMSTestCase(),
 		FindHeightTestCase(),
 		FullAnimationTest(),
-		ActiveObjectTestCase()
+		ActiveObjectTestCase(),
+
+		Issue721TestCase()
 	]
 
 	@IBOutlet weak var testsTable: UITableView!

--- a/WhirlyGlobeSrc/AutoTester/AutoTester/testCases/Issue721TestCase.swift
+++ b/WhirlyGlobeSrc/AutoTester/AutoTester/testCases/Issue721TestCase.swift
@@ -1,0 +1,35 @@
+//
+//  Issue721TestCase.swift
+//  AutoTester
+//
+//  Created by jmnavarro on 24/10/16.
+//  Copyright © 2016 mousebird consulting. All rights reserved.
+//
+import Foundation
+
+class Issue721TestCase : MaplyTestCase{
+
+	override init() {
+		super.init()
+
+		self.name = "Issue 721: Interaction lost bug"
+		self.captureDelay = 4
+		self.implementations = [.globe]
+	}
+
+	override func setUpWithGlobe(_ globeVC: WhirlyGlobeViewController) {
+		let baseLayer = StamenWatercolorRemote()
+		baseLayer.setUpWithGlobe(globeVC)
+
+		DispatchQueue.main.asyncAfter(deadline: .now() + 4.5) {
+			print("Changing frame...")
+			UIView.animate(withDuration: 2.0) {
+				globeVC.view.frame = CGRect(
+					origin: CGPoint.zero,
+					size: CGSize(
+						width: self.testView!.bounds.width/2,
+						height: self.testView!.bounds.height/2))
+			}
+		}
+	}
+}

--- a/WhirlyGlobeSrc/WhirlyGlobeLib/include/IntersectionManager.h
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/include/IntersectionManager.h
@@ -50,6 +50,8 @@ public:
     class Intersectable
     {
     public:
+        virtual ~Intersectable();
+
         // Ray is in display coordinates
         virtual bool findClosestIntersection(WhirlyKitSceneRendererES *renderer,WhirlyKitView *theView,const Point2f &frameSize,const Point2f &touchPt,const Point3d &org,const Point3d &dir,Point3d &iPt,double &dist) = 0;
     };


### PR DESCRIPTION
Hello,

I noticed my system had a small problem with the interaction controls.

When I first open my system, both view are equally distributed on the screen:

![thumb_img_0327_1024](https://cloud.githubusercontent.com/assets/15698398/18177902/20a17b48-704a-11e6-9e98-b05406e95550.jpg)

Then, let's assume I want to see more the 3D view, I expand it (make it bigger):

![thumb_img_0333_1024](https://cloud.githubusercontent.com/assets/15698398/18177927/3a78954c-704a-11e6-9c4c-2f89f2b25e0e.jpg)

At this point, I loose any interaction control in this area of the view:

![thumb_img_0333_1024 interaction controls problem](https://cloud.githubusercontent.com/assets/15698398/18177982/828bf0ea-704a-11e6-958e-22a96a4ee196.jpg)

Would you have any idea of where this comes from? All I do for adjusting the view size is just changing the frame size dynamically. 

Thank you a lot,

Sebastien.
