### PR TITLE
Memory leaks in 2.4.1, MaplyView MaplyInteractionLayer MaplyTextureAtlasGroup MaplyBasicClusterGenerator

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyBaseInteractionLayer.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyBaseInteractionLayer.mm
@@ -284,6 +284,12 @@ public:
     layerThread = nil;
     scene = NULL;
     imageTextures.clear();
+    [userObjects removeAllObjects];
+    userObjects = nil;
+    atlasGroup = nil;
+    glSetupInfo = nil;
+    ourClusterGen.layer = nil;
+    clusterGens.clear();
     [NSObject cancelPreviousPerformRequestsWithTarget:self];
 }
 

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyViewController.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyViewController.mm
@@ -150,6 +150,7 @@ using namespace Maply;
     mapScene = NULL;
     mapView = nil;
     flatView = nil;
+    glView = nil;
 
     mapInteractLayer = nil;
     


### PR DESCRIPTION
Creating a map view and destroying it leaks a handful of objects every time.
For a testcase see https://github.com/trailbehind/WhirlyGlobe/tree/testcase/setup-teardown

In the following screenshot each generation is marked before creating a SimpleTestViewController
<img width="1284" alt="screen shot 2016-02-05 at 11 22 51 am" src="https://cloud.githubusercontent.com/assets/2048291/12855121/d2444866-cbfa-11e5-9e02-3b9b920b6925.png">
