### PR TITLE
AutoTester - CartoDBLight Test Position

### DIFF
--- a/WhirlyGlobeSrc/AutoTester/AutoTester/testCases/CartoDBLightTestCase.m
+++ b/WhirlyGlobeSrc/AutoTester/AutoTester/testCases/CartoDBLightTestCase.m
@@ -48,11 +48,14 @@
 - (void)setUpWithMap:(MaplyViewController *)mapVC
 {
     [self setupBaseLayer:mapVC];
+    mapVC.height = 0.7;
+    [mapVC animateToPosition:MaplyCoordinateMakeWithDegrees(8.4666749, 47.3774337) time:1.0];
 }
 
 - (void)setUpWithGlobe:(WhirlyGlobeViewController *)globeVC
 {
     [self setupBaseLayer:globeVC];
+    [globeVC animateToPosition:MaplyCoordinateMakeWithDegrees(8.4666749, 47.3774337) time:1.0];
 }
 
 @end


### PR DESCRIPTION
The CartoDBLight test case seems to start really close to the surface in map mode.
