### PR TITLE
Bitcode with build-server framework (iOS)

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/WhirlyGlobeMaplyComponent.xcodeproj/project.pbxproj
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/WhirlyGlobeMaplyComponent.xcodeproj/project.pbxproj
@@ -2308,7 +2308,15 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
-				OTHER_CFLAGS = "-DEIGEN_MPL2_ONLY";
+				OTHER_CFLAGS = (
+					"-DEIGEN_MPL2_ONLY",
+					"-fembed-bitcode",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-fembed-bitcode",
+				);
+				OTHER_LDFLAGS = "-fembed-bitcode";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mousebirdconsulting.WhirlyGlobeMaplyComponent;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2349,7 +2357,15 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
-				OTHER_CFLAGS = "-DEIGEN_MPL2_ONLY";
+				OTHER_CFLAGS = (
+					"-DEIGEN_MPL2_ONLY",
+					"-fembed-bitcode",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(OTHER_CFLAGS)",
+					"-fembed-bitcode",
+				);
+				OTHER_LDFLAGS = "-fembed-bitcode";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mousebirdconsulting.WhirlyGlobeMaplyComponent;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/buildframework.sh
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/buildframework.sh
@@ -6,11 +6,11 @@
 # xcodebuild -target WhirlyGlobe-MaplyComponent -configuration Debug -sdk iphonesimulator
 
 # Locations for build products
-BUILT_PRODUCTS_SIMULATOR=`xcodebuild -target WhirlyGlobeMaplyComponent -scheme WhirlyGlobeMaplyComponent -configuration Release -sdk iphonesimulator -showBuildSettings | grep -m 1 "BUILT_PRODUCTS_DIR" | grep -oEi "\/.*"`
-BUILT_PRODUCTS_IPHONEOS=`xcodebuild -target WhirlyGlobeMaplyComponent -scheme WhirlyGlobeMaplyComponent -configuration Release -sdk iphoneos -showBuildSettings | grep -m 1 "BUILT_PRODUCTS_DIR" | grep -oEi "\/.*"`
+BUILT_PRODUCTS_SIMULATOR=`xcodebuild -target WhirlyGlobeMaplyComponent -scheme WhirlyGlobeMaplyComponent -configuration Release -sdk iphonesimulator -showBuildSettings OTHER_CFLAGS='-fembed-bitcode' | grep -m 1 "BUILT_PRODUCTS_DIR" | grep -oEi "\/.*"`
+BUILT_PRODUCTS_IPHONEOS=`xcodebuild -target WhirlyGlobeMaplyComponent -scheme WhirlyGlobeMaplyComponent -configuration Release -sdk iphoneos -showBuildSettings OTHER_CFLAGS='-fembed-bitcode' | grep -m 1 "BUILT_PRODUCTS_DIR" | grep -oEi "\/.*"`
 
-xcodebuild -target WhirlyGlobeMaplyComponent -scheme WhirlyGlobeMaplyComponent -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPad 2' clean build
-xcodebuild -target WhirlyGlobeMaplyComponent -scheme WhirlyGlobeMaplyComponent -configuration Release -sdk iphoneos -DONLY_ACTIVE_ARCH=NO
+xcodebuild -target WhirlyGlobeMaplyComponent -scheme WhirlyGlobeMaplyComponent -configuration Release -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPad 2' OTHER_CFLAGS='-fembed-bitcode' clean build
+xcodebuild -target WhirlyGlobeMaplyComponent -scheme WhirlyGlobeMaplyComponent -configuration Release -sdk iphoneos -DONLY_ACTIVE_ARCH=NO OTHER_CFLAGS='-fembed-bitcode'
 
 # name and build location
 PROJECT_NAME=WhirlyGlobeMaplyComponent

--- a/WhirlyGlobeSrc/WhirlyGlobeLib/WhirlyGlobeLib.xcodeproj/project.pbxproj
+++ b/WhirlyGlobeSrc/WhirlyGlobeLib/WhirlyGlobeLib.xcodeproj/project.pbxproj
@@ -2662,9 +2662,9 @@
 					../local_libs/octencoding/,
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
-				OTHER_CFLAGS = "";
+				OTHER_CFLAGS = "-fembed-bitcode";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
-				OTHER_LDFLAGS = "";
+				OTHER_LDFLAGS = "-fembed-bitcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				VALID_ARCHS = "armv7 armv7s arm64";
@@ -2706,9 +2706,9 @@
 					../local_libs/octencoding/,
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
-				OTHER_CFLAGS = "";
+				OTHER_CFLAGS = "-fembed-bitcode";
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
-				OTHER_LDFLAGS = "";
+				OTHER_LDFLAGS = "-fembed-bitcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				VALID_ARCHS = "armv7 armv7s arm64";


### PR DESCRIPTION
Hey there! Firstly, thanks for all the work on this awesome project. Really enjoying working with it.

Up until recently, I was using WhirlyGlobe with a CocoaPods install. However, due to the slow compilation times, I switched to using the compiled framework from the new build server.

I'm currently referencing the following zip in my Podfile:
`https://s3-us-west-1.amazonaws.com/whirlyglobemaplydistribution/iOS_daily_builds/WhirlyGlobe-Maply_68.zip`

I went to archive my app for the first time since making this change, however, I encountered the following issue:

```
❌  ld: bitcode bundle could not be generated because '~/Pods/WhirlyGlobe/WhirlyGlobeMaplyComponent.framework/WhirlyGlobeMaplyComponent(MaplySun.o)' was built without full bitcode. 
All object files and libraries for bitcode must be generated from Xcode Archive or Install build for architecture armv7



❌  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

My configuration uses Bitcode, but I assume the compiled framework doesn't (which is causing this error). I disabled Bitcode and it compiled without a problem.


What's the suggested course of action in this situation if I were to want to use Bitcode? 
Not sure if Bitcode compilation is something that needs to be supported on Mousebird's end or if I have something badly configured on mine. 

If it's any hassle, I can compile it into a framework myself locally with Bitcode enabled (which should hopefully allow for it to compile when included with my app). Thanks in advance.