### PR TITLE
[iOS Swift] Cannot change ScreenLabelColor

### DIFF
--- a/WhirlyGlobeSrc/AutoTester/AutoTester/testCases/ScreenLabelsTestCase.swift
+++ b/WhirlyGlobeSrc/AutoTester/AutoTester/testCases/ScreenLabelsTestCase.swift
@@ -60,7 +60,7 @@ class ScreenLabelsTestCase: MaplyTestCase {
 							kMaplyShadowColor: UIColor.black,
 							kMaplyShadowSize: 1.0,
                             kMaplySelectable: true,
-							kMaplyColor: UIColor.white]) {
+							kMaplyTextColor: UIColor.white]) {
 						labelList.append(comp)
 					}
 				}
@@ -71,7 +71,7 @@ class ScreenLabelsTestCase: MaplyTestCase {
 							kMaplyTextOutlineColor: UIColor.black,
 							kMaplyTextOutlineSize: 2.0,
                             kMaplySelectable: true,
-							kMaplyColor: UIColor.white]) {
+							kMaplyTextColor: UIColor.lightGray]) {
 						labelList.append(comp)
 					}
 				}


### PR DESCRIPTION
I have played a bit withe iOS / Swift version of the kit and it seems kMaplyColor has no effect on screen labels font color (when used from Swift).

Pretty easy to reproduce:
- open ScreenLabelsTextCase.swift
- modify line 63 to kMaplyColor: UIColor.green
- modify line 74 to kMaplyColor: UIColor.red
- run the test

What should happen:
- half of labels should be red with a black outline
- the other half should be green with a black shadow

What happens:
- labels are all white (with either a black outline or a black shadow).

