### PR TITLE
SLD marker/label offset VendorOption changes

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/vector_tiles/SLDSymbolizers.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/vector_tiles/SLDSymbolizers.h
@@ -34,7 +34,7 @@
  @see MaplyVectorTileStyle
  @see MaplyVectorStyleSettings
  */
-+ (NSArray<MaplyVectorTileStyle *> * _Nullable) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings * _Nonnull)tileStyleSettings viewC:(MaplyBaseViewController * _Nonnull)viewC minScaleDenom:(NSNumber * _Nonnull)minScaleDenom maxScaleDenom:(NSNumber * _Nonnull)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority baseURL:(NSURL * _Nonnull)baseURL;
++ (NSArray<MaplyVectorTileStyle *> * _Nullable) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings * _Nonnull)tileStyleSettings viewC:(MaplyBaseViewController * _Nonnull)viewC minScaleDenom:(NSNumber * _Nonnull)minScaleDenom maxScaleDenom:(NSNumber * _Nonnull)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority crossSymbolizerParams:(NSMutableDictionary *)crossSymbolizerParams baseURL:(NSURL * _Nonnull)baseURL;
 @end
 
 /** @brief Class corresponding to the LineSymbolizer element

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileTextStyle.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileTextStyle.mm
@@ -45,6 +45,7 @@ typedef enum {
     TextSymbolizerTextTransform textTransform;
     NSString *textField;
     float layoutImportance;
+    NSNumber *layoutPlacement;
 }
 
 @end
@@ -189,6 +190,15 @@ typedef enum {
                 subStyle->placement = TextPlacementVertex;
         }
         
+        if(styleEntry[@"layout-placement"]) {
+            NSString *sLayoutPlacement = styleEntry[@"layout-placement"];
+            @try {
+                int layoutPlacement = [sLayoutPlacement intValue];
+                subStyle->layoutPlacement = @(layoutPlacement);
+            } @finally {
+            }
+        }
+        
         subStyle->textTransform = TextTransformNone;
         if(styleEntry[@"text-transform"])
         {
@@ -310,6 +320,8 @@ typedef enum {
                     [labels addObject:label];
                 }
             }
+            if (subStyle->layoutPlacement)
+                label.layoutPlacement = [subStyle->layoutPlacement intValue];
         }
 
         // Note: This should be MaplyThreadCurrent, but...

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/SLDStyleSet.m
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/SLDStyleSet.m
@@ -302,9 +302,11 @@
     if (rule.relativeDrawPriority)
         relativeDrawPriority += rule.relativeDrawPriority.intValue;
     
+    // Allows certain params from symbolizers to be accessed by subsequent symbolizers within a rule.
+    NSMutableDictionary *crossSymbolizerParams = [NSMutableDictionary dictionary];
+    
     for (DDXMLNode *child in [ruleNode children]) {
-//        NSString *name = [child localName];
-        NSArray <MaplyVectorTileStyle *> *symbolizers = [SLDSymbolizer maplyVectorTileStyleWithElement:(DDXMLElement *)child tileStyleSettings:self.tileStyleSettings viewC:self.viewC minScaleDenom:rule.minScaleDenominator maxScaleDenom:rule.maxScaleDenominator relativeDrawPriority:_relativeDrawPriority baseURL:_baseURL];
+        NSArray <MaplyVectorTileStyle *> *symbolizers = [SLDSymbolizer maplyVectorTileStyleWithElement:(DDXMLElement *)child tileStyleSettings:self.tileStyleSettings viewC:self.viewC minScaleDenom:rule.minScaleDenominator maxScaleDenom:rule.maxScaleDenominator relativeDrawPriority:_relativeDrawPriority crossSymbolizerParams:crossSymbolizerParams baseURL:_baseURL];
         
         if (symbolizers) {
             _relativeDrawPriority += 1;

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/SLDSymbolizers.m
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/vector_tiles/SLDSymbolizers.m
@@ -9,6 +9,7 @@
 #import "SLDSymbolizers.h"
 #import "SLDWellKnownMarkers.h"
 #import "MaplyVectorTiles.h"
+#import "MaplyScreenLabel.h"
 
 @implementation SLDSymbolizer
 
@@ -25,7 +26,7 @@
  @see MaplyVectorTileStyle
  @see MaplyVectorStyleSettings
  */
-+ (NSArray<MaplyVectorTileStyle *> *) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority baseURL:(NSURL *)baseURL {
++ (NSArray<MaplyVectorTileStyle *> *) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority crossSymbolizerParams:(NSMutableDictionary *)crossSymbolizerParams baseURL:(NSURL *)baseURL {
     
     static NSMutableDictionary *zOrderGroups;
     if (!zOrderGroups)
@@ -59,13 +60,13 @@
     }
     
     if ([SLDLineSymbolizer matchesSymbolizerNamed:name])
-        return [SLDLineSymbolizer maplyVectorTileStyleWithElement:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:overrideRelativeDrawPriority baseURL:baseURL];
+        return [SLDLineSymbolizer maplyVectorTileStyleWithElement:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:overrideRelativeDrawPriority crossSymbolizerParams:crossSymbolizerParams baseURL:baseURL];
     else if ([SLDPolygonSymbolizer matchesSymbolizerNamed:name])
-        return [SLDPolygonSymbolizer maplyVectorTileStyleWithElement:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:overrideRelativeDrawPriority baseURL:baseURL];
+        return [SLDPolygonSymbolizer maplyVectorTileStyleWithElement:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:overrideRelativeDrawPriority crossSymbolizerParams:crossSymbolizerParams baseURL:baseURL];
     else if ([SLDPointSymbolizer matchesSymbolizerNamed:name])
-        return [SLDPointSymbolizer maplyVectorTileStyleWithElement:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:overrideRelativeDrawPriority baseURL:baseURL];
+        return [SLDPointSymbolizer maplyVectorTileStyleWithElement:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:overrideRelativeDrawPriority crossSymbolizerParams:crossSymbolizerParams baseURL:baseURL];
     else if ([SLDTextSymbolizer matchesSymbolizerNamed:name])
-        return [SLDTextSymbolizer maplyVectorTileStyleWithElement:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:overrideRelativeDrawPriority baseURL:baseURL];
+        return [SLDTextSymbolizer maplyVectorTileStyleWithElement:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:overrideRelativeDrawPriority crossSymbolizerParams:crossSymbolizerParams baseURL:baseURL];
     return nil;
 }
 
@@ -400,7 +401,7 @@
 
 /** @brief See comment for SLDSymbolizer maplyVectorTileStyleWithElement:tileStyleSettings:viewC:minScaleDenom:maxScaleDenom:
  */
-+ (NSArray<MaplyVectorTileStyle *> *) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority baseURL:(NSURL *)baseURL {
++ (NSArray<MaplyVectorTileStyle *> *) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority crossSymbolizerParams:(NSMutableDictionary *)crossSymbolizerParams baseURL:(NSURL *)baseURL {
     
     DDXMLElement *strokeNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:element childName:@"Stroke"];
     
@@ -456,7 +457,7 @@
 
 /** @brief See comment for SLDSymbolizer maplyVectorTileStyleWithElement:tileStyleSettings:viewC:minScaleDenom:maxScaleDenom:
  */
-+ (NSArray<MaplyVectorTileStyle *> *) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority baseURL:(NSURL *)baseURL {
++ (NSArray<MaplyVectorTileStyle *> *) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority crossSymbolizerParams:(NSMutableDictionary *)crossSymbolizerParams baseURL:(NSURL *)baseURL {
     
     DDXMLElement *fillNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:element childName:@"Fill"];
     DDXMLElement *strokeNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:element childName:@"Stroke"];
@@ -529,9 +530,9 @@
 
 /** @brief See comment for SLDSymbolizer maplyVectorTileStyleWithElement:tileStyleSettings:viewC:minScaleDenom:maxScaleDenom:
  */
-+ (NSArray<MaplyVectorTileStyle *> *) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority baseURL:(NSURL *)baseURL {
++ (NSArray<MaplyVectorTileStyle *> *) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority crossSymbolizerParams:(NSMutableDictionary *)crossSymbolizerParams baseURL:(NSURL *)baseURL {
     
-    MaplyVectorTileStyle *s = [SLDPointSymbolizer maplyVectorTileStyleFromPointSymbolizerNode:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:relativeDrawPriority baseURL:baseURL];
+    MaplyVectorTileStyle *s = [SLDPointSymbolizer maplyVectorTileStyleFromPointSymbolizerNode:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:relativeDrawPriority crossSymbolizerParams:crossSymbolizerParams baseURL:baseURL];
     
     if (!s)
         return nil;
@@ -541,7 +542,7 @@
 
 /** @brief Parses a PointSymbolizer node and returns a corresponding MaplyVectorTileStyle object.
  */
-+ (MaplyVectorTileStyle *)maplyVectorTileStyleFromPointSymbolizerNode:(DDXMLElement *)pointSymbolizerNode tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority baseURL:(NSURL *)baseURL {
++ (MaplyVectorTileStyle *)maplyVectorTileStyleFromPointSymbolizerNode:(DDXMLElement *)pointSymbolizerNode tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority crossSymbolizerParams:(NSMutableDictionary *)crossSymbolizerParams baseURL:(NSURL *)baseURL {
     
     DDXMLElement *graphicNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:pointSymbolizerNode childName:@"Graphic"];
     
@@ -556,6 +557,11 @@
         pointParams[@"minscaledenom"] = minScaleDenom;
     if (maxScaleDenom)
         pointParams[@"maxscaledenom"] = maxScaleDenom;
+    
+    if (pointParams[@"width"] && pointParams[@"height"]) {
+        crossSymbolizerParams[@"width"] = pointParams[@"width"];
+        crossSymbolizerParams[@"height"] = pointParams[@"height"];
+    }
     
     MaplyVectorTileStyle *s = [MaplyVectorTileStyle styleFromStyleEntry:@{@"type": @"MarkersSymbolizer", @"substyles": @[pointParams]}
                                                                settings:tileStyleSettings
@@ -575,9 +581,9 @@
 
 /** @brief See comment for SLDSymbolizer maplyVectorTileStyleWithElement:tileStyleSettings:viewC:minScaleDenom:maxScaleDenom:
  */
-+ (NSArray<MaplyVectorTileStyle *> *) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority baseURL:(NSURL *)baseURL {
++ (NSArray<MaplyVectorTileStyle *> *) maplyVectorTileStyleWithElement:(DDXMLElement * _Nonnull)element tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority crossSymbolizerParams:(NSMutableDictionary *)crossSymbolizerParams baseURL:(NSURL *)baseURL {
     
-    MaplyVectorTileStyle *s = [SLDTextSymbolizer maplyVectorTileStyleFromTextSymbolizerNode:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:relativeDrawPriority baseURL:baseURL];
+    MaplyVectorTileStyle *s = [SLDTextSymbolizer maplyVectorTileStyleFromTextSymbolizerNode:element tileStyleSettings:tileStyleSettings viewC:viewC minScaleDenom:minScaleDenom maxScaleDenom:maxScaleDenom relativeDrawPriority:relativeDrawPriority crossSymbolizerParams:crossSymbolizerParams baseURL:baseURL];
     
     if (!s)
         return nil;
@@ -587,11 +593,11 @@
 
 /** @brief Parses a TextSymbolizer node and returns a corresponding MaplyVectorTileStyle object.
  */
-+ (MaplyVectorTileStyle *)maplyVectorTileStyleFromTextSymbolizerNode:(DDXMLElement *)textSymbolizerNode tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority baseURL:(NSURL *)baseURL {
++ (MaplyVectorTileStyle *)maplyVectorTileStyleFromTextSymbolizerNode:(DDXMLElement *)textSymbolizerNode tileStyleSettings:(MaplyVectorStyleSettings *)tileStyleSettings viewC:(MaplyBaseViewController *)viewC minScaleDenom:(NSNumber *)minScaleDenom maxScaleDenom:(NSNumber *)maxScaleDenom relativeDrawPriority:(int)relativeDrawPriority crossSymbolizerParams:(NSMutableDictionary *)crossSymbolizerParams baseURL:(NSURL *)baseURL {
     
     NSMutableDictionary *labelParams = [NSMutableDictionary dictionary];
     
-    labelParams[@"dx"] = @(25);
+    labelParams[@"dx"] = @(10);
     labelParams[@"dy"] = @(0);
     
     // Label text
@@ -625,6 +631,38 @@
             
             DDXMLElement *anchorPointNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:pointPlacementNode childName:@"AnchorPoint"];
             DDXMLElement *displacementNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:pointPlacementNode childName:@"Displacement"];
+            
+            if (anchorPointNode) {
+                DDXMLElement *anchorPointXNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:anchorPointNode childName:@"AnchorPointX"];
+                DDXMLElement *anchorPointYNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:anchorPointNode childName:@"AnchorPointY"];
+                NSString *sAnchorPointX, *sAnchorPointY;
+                if (anchorPointXNode)
+                    sAnchorPointX = [SLDSymbolizer stringForLiteralInNode:anchorPointXNode];
+                if (anchorPointYNode)
+                    sAnchorPointY = [SLDSymbolizer stringForLiteralInNode:anchorPointYNode];
+                float anchorPointX = 0.0;
+                if (sAnchorPointX)
+                    anchorPointX = [sAnchorPointX floatValue];
+                float anchorPointY = 0.5;
+                if (sAnchorPointY)
+                    anchorPointY = [sAnchorPointY floatValue];
+                
+                int layoutPlacement;
+                if (anchorPointX <= 0.33)
+                    layoutPlacement = kMaplyLayoutRight;
+                else if (anchorPointX > 0.67)
+                    layoutPlacement = kMaplyLayoutLeft;
+                else {
+                    if (anchorPointY <= 0.33)
+                        layoutPlacement = kMaplyLayoutBelow;
+                    else if (anchorPointY > 0.67)
+                        layoutPlacement = kMaplyLayoutAbove;
+                    else
+                        layoutPlacement = kMaplyLayoutCenter;
+                }
+                labelParams[@"layout-placement"] = @(layoutPlacement);
+            }
+            
             if (displacementNode) {
                 DDXMLElement *displacementXNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:displacementNode childName:@"DisplacementX"];
                 DDXMLElement *displacementYNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:displacementNode childName:@"DisplacementY"];
@@ -633,15 +671,16 @@
                     sDisplacementX = [SLDSymbolizer stringForLiteralInNode:displacementXNode];
                 if (displacementYNode)
                     sDisplacementY = [SLDSymbolizer stringForLiteralInNode:displacementYNode];
-                int displacementX = 25;
+                int displacementX = [labelParams[@"dx"] intValue];
                 if (sDisplacementX)
                     displacementX = [sDisplacementX intValue];
-                int displacementY = 0;
+                int displacementY = [labelParams[@"dy"] intValue];
                 if (sDisplacementY)
                     displacementY = [sDisplacementY intValue];
                 labelParams[@"dx"] = @(displacementX);
                 labelParams[@"dy"] = @(displacementY);
             }
+            
         } else if (linePlacementNode) {
             
             DDXMLElement *perpendicularOffsetNode = (DDXMLElement *)[SLDSymbolizer getSingleChildNodeForNode:linePlacementNode childName:@"PerpendicularOffset"];
@@ -687,6 +726,41 @@
             labelParams[@"fill"] = labelFillParams[@"fill"];
         if (labelFillParams && labelFillParams[@"fill-opacity"])
             labelParams[@"opacity"] = labelFillParams[@"fill-opacity"];
+    }
+    
+    NSArray *vendorOptionNodes = [textSymbolizerNode elementsForName:@"VendorOption"];
+    if (vendorOptionNodes) {
+        NSMutableDictionary *markerRelation = [NSMutableDictionary dictionary];
+        @try {
+            for (DDXMLElement *vendorOptionNode in vendorOptionNodes) {
+                DDXMLNode *optionNameNode = [vendorOptionNode attributeForName:@"name"];
+                NSString *optionName;
+                if (optionNameNode)
+                    optionName = [optionNameNode stringValue];
+                
+                if (optionName && [@[@"markerXScale", @"markerXOffset", @"markerYScale", @"markerYOffset"] containsObject:optionName]) {
+                    float f = [[self stringForLiteralInNode:vendorOptionNode] floatValue];
+                    markerRelation[optionName] = @(f);
+                }
+            }
+        } @finally {
+        }
+        NSNumber *markerXScale = markerRelation[@"markerXScale"];
+        NSNumber *markerXOffset = markerRelation[@"markerXOffset"];
+        NSNumber *markerYScale = markerRelation[@"markerYScale"];
+        NSNumber *markerYOffset = markerRelation[@"markerYOffset"];
+        if (markerXScale && markerXOffset && markerYScale && markerYOffset && crossSymbolizerParams[@"width"] && crossSymbolizerParams[@"height"]) {
+            @try {
+                NSNumber *markerWidth = @([crossSymbolizerParams[@"width"] floatValue]);
+                NSNumber *markerHeight = @([crossSymbolizerParams[@"height"] floatValue]);
+                int dx = (int)(markerXScale.floatValue * markerWidth.floatValue + markerXOffset.floatValue);
+                int dy = (int)(markerYScale.floatValue * markerHeight.floatValue + markerYOffset.floatValue);
+                labelParams[@"placement"] = @"point";
+                labelParams[@"dx"] = @(dx);
+                labelParams[@"dy"] = @(dy);
+            } @finally {
+            }
+        }
     }
 
     labelParams[@"drawpriority"] = @(relativeDrawPriority);


### PR DESCRIPTION
SLD marker/label offset VendorOption changes.

Allows label offset to be expressed as a multiple of the marker size, plus an offset, in both horizontal and vertical directions.

Demonstrated in the new amenities.sld, e.g.:

```
<VendorOption name="markerXScale">0</VendorOption>                                                        
<VendorOption name="markerXOffset">20</VendorOption>                                                      
<VendorOption name="markerYScale">0</VendorOption>
<VendorOption name="markerYOffset">0</VendorOption>

```
