### PR TITLE
Load ShapeFile from documents

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyVectorObject.h
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/include/MaplyVectorObject.h
@@ -356,6 +356,12 @@ typedef MaplyVectorObject WGVectorObject;
  */
 - (nonnull instancetype)initWithShape:(NSString *__nonnull)shapeName;
 
+/** @brief Construct from a shapfile in the apps documents
+    @details Construct a MaplyVectorDabase from a shapefile found in the app's bundle. This will create a bounding box cache file and a sqlite database for the attributes to speed later lookups.
+ */
+- (nonnull instancetype)initWithShapefileInDocuments:(NSString *__nonnull)shapeName;
+
+
 /** @brief Return vectors that match the given SQL query
     @details Run a SQL query on the data, looking for vectors that match.  These will be returned in a single MaplyVectorObject, or nil if there are none.
   */

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyVectorObject.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyVectorObject.mm
@@ -1722,9 +1722,6 @@ public:
         NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
         NSString *documentsDirectory = [paths objectAtIndex:0];
         NSString *filePath = [documentsDirectory stringByAppendingPathComponent: shapeName];
-
-        //VectorDatabase(NSString *bundleDir,NSString *cacheDir,NSString *baseName,VectorReader *reader,const std::set<std::string> *indices,bool cache=false,bool autoload=false);
-
         VectorDatabase *vecDb = new VectorDatabase(documentsDirectory, documentsDirectory, shapeName, new ShapeReader(filePath), NULL);
 
         vectorDb = vecDb;

--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyVectorObject.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyVectorObject.mm
@@ -1715,6 +1715,26 @@ public:
 	return self;
 }
 
+- (instancetype)initWithShapefileInDocuments:(NSString *)shapeName
+{
+    if (self = [super init]) {
+
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+        NSString *documentsDirectory = [paths objectAtIndex:0];
+        NSString *filePath = [documentsDirectory stringByAppendingPathComponent: shapeName];
+
+        //VectorDatabase(NSString *bundleDir,NSString *cacheDir,NSString *baseName,VectorReader *reader,const std::set<std::string> *indices,bool cache=false,bool autoload=false);
+
+        VectorDatabase *vecDb = new VectorDatabase(documentsDirectory, documentsDirectory, shapeName, new ShapeReader(filePath), NULL);
+
+        vectorDb = vecDb;
+        baseName = shapeName;
+    }
+
+    return self;
+}
+
+
 
 /// Construct from a shapefile in the bundle
 + (MaplyVectorDatabase *) vectorDatabaseWithShape:(NSString *)shapeName


### PR DESCRIPTION
This is a very small addition to allow loading a `MaplyVectorDatabase` from a file in the apps documents directory.

Currently you can only load a shapefile that lives in the apps bundled resources:

`let vectorDatabase = MaplyVectorDatabase(shape: "World Borders")`

The addition allows you to load a file into the apps Documents directory through iTunes and load it with:

`let vectorDatabase = MaplyVectorDatabase(shapefileInDocuments: "My shapefile")`