### PR TITLE
load ShapeFile from documents from ChrisLowe-Takor

### DIFF
--- a/ios/library/WhirlyGlobe-MaplyComponent/include/MaplyVectorObject.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/MaplyVectorObject.h
@@ -361,6 +361,11 @@ typedef MaplyVectorObject WGVectorObject;
  */
 - (nonnull instancetype)initWithShape:(NSString *__nonnull)shapeName;
 
+/** @brief Construct from a shapfile in the apps documents
+    @details Construct a MaplyVectorDabase from a shapefile found in the app's bundle. This will create a bounding box cache file and a sqlite database for the attributes to speed later lookups.
+ */
+- (nonnull instancetype)initWithShapefileInDocuments:(NSString *__nonnull)shapeName;
+
 /** @brief Return vectors that match the given SQL query
     @details Run a SQL query on the data, looking for vectors that match.  These will be returned in a single MaplyVectorObject, or nil if there are none.
   */

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/MaplyVectorObject.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/MaplyVectorObject.mm
@@ -1746,6 +1746,22 @@ public:
 	return self;
 }
 
+- (instancetype)initWithShapefileInDocuments:(NSString *)shapeName
+{
+    if (self = [super init]) {
+
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+        NSString *documentsDirectory = [paths objectAtIndex:0];
+        NSString *filePath = [documentsDirectory stringByAppendingPathComponent: shapeName];
+        VectorDatabase *vecDb = new VectorDatabase(documentsDirectory, documentsDirectory, shapeName, new ShapeReader(filePath), NULL);
+
+        vectorDb = vecDb;
+        baseName = shapeName;
+    }
+
+    return self;
+}
+
 
 /// Construct from a shapefile in the bundle
 + (MaplyVectorDatabase *) vectorDatabaseWithShape:(NSString *)shapeName


### PR DESCRIPTION
load ShapeFile from documents from ChrisLowe-Takor

https://github.com/mousebird/WhirlyGlobe/pull/878

> This is a very small addition to allow loading a `MaplyVectorDatabase` from a file in the apps documents directory.
> 
> Currently you can only load a shapefile that lives in the apps bundled resources:
> 
> `let vectorDatabase = MaplyVectorDatabase(shape: "World Borders")`
> 
> The addition allows you to load a file into the apps Documents directory through iTunes and load it with:
> 
> `let vectorDatabase = MaplyVectorDatabase(shapefileInDocuments: "My shapefile")`