### PR TITLE
Refs #885 : Upgrading to latest build tools

### DIFF
--- a/android/apps/AutoTesterAndroid/app/build.gradle
+++ b/android/apps/AutoTesterAndroid/app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.mousebirdconsulting.autotester"
         minSdkVersion 14
-        targetSdkVersion 24
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -22,13 +22,16 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.android.support:design:23.1.1'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.jakewharton:butterknife:6.1.0'
-    compile 'com.squareup.okhttp:okhttp:2.3.0'
+    compile ('com.android.support:appcompat-v7:23.1.1')
+    compile ('com.android.support:design:23.1.1'){
+        exclude group: 'com.android.support', module: 'support-v4'
+    }
+    compile ('com.jakewharton:butterknife:6.1.0')
+    compile ('com.squareup.okhttp:okhttp:2.3.0')
     compile 'org.apache.directory.studio:org.apache.commons.io:2.4'
-    compile 'com.squareup.okio:okio:1.3.0'
-    compile project(':Maply')
-    compile 'org.jodd:jodd-core:3.6.7'
+    compile ('com.squareup.okio:okio:1.3.0')
+    compile (project(':Maply')) {
+        exclude group: 'com.android.support', module: 'support-v4'
+    }
+    compile ('org.jodd:jodd-core:3.6.7')
 }

--- a/android/apps/AutoTesterAndroid/app/build.gradle
+++ b/android/apps/AutoTesterAndroid/app/build.gradle
@@ -22,16 +22,12 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile ('com.android.support:appcompat-v7:23.1.1')
-    compile ('com.android.support:design:23.1.1'){
-        exclude group: 'com.android.support', module: 'support-v4'
-    }
-    compile ('com.jakewharton:butterknife:6.1.0')
-    compile ('com.squareup.okhttp:okhttp:2.3.0')
+    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:design:23.1.1'
+    compile 'com.jakewharton:butterknife:6.1.0'
+    compile 'com.squareup.okhttp:okhttp:2.3.0'
     compile 'org.apache.directory.studio:org.apache.commons.io:2.4'
-    compile ('com.squareup.okio:okio:1.3.0')
-    compile (project(':Maply')) {
-        exclude group: 'com.android.support', module: 'support-v4'
-    }
-    compile ('org.jodd:jodd-core:3.6.7')
+    compile 'com.squareup.okio:okio:1.3.0'
+    compile project(':Maply')
+    compile 'org.jodd:jodd-core:3.6.7'
 }

--- a/android/apps/AutoTesterAndroid/build.gradle
+++ b/android/apps/AutoTesterAndroid/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/library/Android/build.gradle
+++ b/android/library/Android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.0"

--- a/android/library/Android/build.gradle
+++ b/android/library/Android/build.gradle
@@ -1,11 +1,14 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
-        classpath 'com.github.dcendents:android-maven-plugin:1.2'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.0"
     }
 }
@@ -29,7 +32,7 @@ apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "25.0.2"
 
     sourceSets {
         main {
@@ -49,7 +52,7 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-project.txt'), 'proguard-rules.txt'
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
     
@@ -59,16 +62,15 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:23.0.0'
+    compile 'com.android.support:support-v4:23.1.1'
     compile 'com.squareup.okhttp:okhttp:2.3.0'
     compile 'com.squareup.okio:okio:1.3.0'
     compile 'org.apache.directory.studio:org.apache.commons.io:2.4'
 
 }
 
-import org.gradle.internal.os.OperatingSystem;
-import org.apache.tools.ant.taskdefs.condition.Os;
 
+import org.apache.tools.ant.taskdefs.condition.Os
 
 task buildHeaders(type: Exec, description: 'Build headers to be used on native build') {
     Properties properties = new Properties()
@@ -78,7 +80,7 @@ task buildHeaders(type: Exec, description: 'Build headers to be used on native b
 
 
 task buildNative(type: Exec, description: 'Compile native code using NDK') {
-    def ndkDir = plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder()
+    def ndkDir = project.android.ndkDirectory
 
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         commandLine "$ndkDir/ndk-build.cmd",
@@ -98,7 +100,7 @@ task buildNative(type: Exec, description: 'Compile native code using NDK') {
 }
 
 task cleanNative(type: Exec, description: 'Clean native compiled code') {
-    def ndkDir = plugins.getPlugin('com.android.library').sdkHandler.getNdkFolder()
+    def ndkDir = project.android.ndkDirectory
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         commandLine "$ndkDir/ndk-build.cmd",
             '-C', file('.').absolutePath,

--- a/android/library/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/library/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Feb 07 11:34:58 CET 2016
+#Mon Apr 10 14:54:14 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
I have made an attempt at upgrading everything but had to roll back on the library.

For a reason I fail to understand, if the library is built with an Android Gradle plugin above 2.2.x, the application cannot be dexed (see #889).