### PR TITLE
Mirrored Java methods Mbr.insideOrOnEdge and Mbr.expandByFraction

### DIFF
--- a/ios/library/WhirlyGlobe-MaplyComponent/include/MaplyCoordinate.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/MaplyCoordinate.h
@@ -191,10 +191,20 @@ MaplyCoordinate3dD MaplyCoordinate3dDMake(double x,double y,double z);
 MaplyBoundingBox MaplyBoundingBoxMakeWithDegrees(float degLon0,float degLat0,float degLon1,float degLat1);
     
 /** @brief Check if two bounding boxes overlap.
-    @return Returns true if they did overlap, false otherwise.
- */
+     @return Returns true if they did overlap, false otherwise.
+  */
 bool MaplyBoundingBoxesOverlap(MaplyBoundingBox bbox0,MaplyBoundingBox bbox1);
-
+    
+/** @brief Check if a bounding contains a given coordinate.
+     @return Returns true if the bounding box contains the coordinate.
+  */
+bool MaplyBoundingBoxContains(MaplyBoundingBox bbox, MaplyCoordinate c);
+    
+/** @brief Expands a bounding box by a given fraction of its size.
+     @return Returns the expanded bounding box.
+  */
+MaplyBoundingBox MaplyBoundingBoxExpandByFraction(MaplyBoundingBox bbox, float buffer);
+    
 /** @brief Calculate the great circle distance between two geo coordinates.
     @details This calculates the distance on a sphere between one point and another.
     @param p0 The starting point, lon/lat in radians.

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/MaplyCoordinate.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/MaplyCoordinate.mm
@@ -98,9 +98,37 @@ bool MaplyBoundingBoxesOverlap(MaplyBoundingBox bbox0,MaplyBoundingBox bbox1)
     mbr0.ur() = Point2f(bbox0.ur.x,bbox0.ur.y);
     mbr1.ll() = Point2f(bbox1.ll.x,bbox1.ll.y);
     mbr1.ur() = Point2f(bbox1.ur.x,bbox1.ur.y);
-    
+
     return mbr0.overlaps(mbr1);
 }
+
+bool MaplyBoundingBoxContains(MaplyBoundingBox bbox, MaplyCoordinate c)
+{
+    Mbr mbr;
+    Point2f point = Point2f(c.x, c.y);
+    mbr.ll() = Point2f(bbox.ll.x,bbox.ll.y);
+    mbr.ur() = Point2f(bbox.ur.x,bbox.ur.y);
+
+    return mbr.insideOrOnEdge(point);
+}
+
+
+MaplyBoundingBox MaplyBoundingBoxExpandByFraction(MaplyBoundingBox bbox, float buffer)
+{
+    Mbr mbr;
+    mbr.ll() = Point2f(bbox.ll.x,bbox.ll.y);
+    mbr.ur() = Point2f(bbox.ur.x,bbox.ur.y);
+
+    mbr.expandByFraction(buffer);
+
+    MaplyBoundingBox r;
+    r.ll = MaplyCoordinateMake(mbr.ll().x(), mbr.ll().y());
+    r.ur = MaplyCoordinateMake(mbr.ur().x(), mbr.ur().y());
+
+    return r;
+}
+
+
 
 double MaplyGreatCircleDistance(MaplyCoordinate p0,MaplyCoordinate p1)
 {

--- a/ios/library/WhirlyGlobeLib/include/WhirlyVector.h
+++ b/ios/library/WhirlyGlobeLib/include/WhirlyVector.h
@@ -112,6 +112,9 @@ public:
     /// Middle
     const Point2f mid() const { return (pt_ll+pt_ur)/2.0; }
 
+    /// span
+    Point2f span() const;
+
 	/// Check validity
 	bool valid() const { return pt_ur.x() >= pt_ll.x(); }
 	
@@ -151,7 +154,10 @@ public:
     
     /// Expand with the given MBR
     void expand(const Mbr &that);
-	
+
+    /// Expands by a given fraction of the receiver's size
+    void expandByFraction(double bufferZone);
+
 protected:
 	Point2f pt_ll,pt_ur;
 };

--- a/ios/library/WhirlyGlobeLib/src/WhirlyVector.mm
+++ b/ios/library/WhirlyGlobeLib/src/WhirlyVector.mm
@@ -104,6 +104,12 @@ float Mbr::area() const
 {
 	return (pt_ur.x() - pt_ll.x())*(pt_ur.y() - pt_ll.y());
 }
+
+Point2f Mbr::span() const
+{
+    return Point2f(pt_ur.x()-pt_ll.x(),pt_ur.y()-pt_ll.y());
+}
+
     
 void Mbr::expand(const Mbr &that)
 {
@@ -111,6 +117,16 @@ void Mbr::expand(const Mbr &that)
     addPoint(that.pt_ur);
 }
 
+
+void Mbr::expandByFraction(double bufferZone)
+{
+    Point2f spanViewMbr = span();
+    pt_ll.x() = pt_ll.x()-spanViewMbr.x()*bufferZone;
+    pt_ll.y() = pt_ll.y()-spanViewMbr.y()*bufferZone;
+    pt_ur.x() = pt_ur.x()+spanViewMbr.x()*bufferZone;
+    pt_ur.y() = pt_ur.y()+spanViewMbr.y()*bufferZone;
+}
+    
     
 void Mbr::asPoints(std::vector<Point2f> &pts) const
 {


### PR DESCRIPTION
Provides the same features as Java methods Mbr.insideOrOnEdge and Mbr.expandByFraction at the MaplyBoundingBox level.

Refs #900