### PR TITLE
choose backface shader for polys

### DIFF
--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorStyleSimple.m
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorStyleSimple.m
@@ -130,6 +130,7 @@
     }
     
     MaplyComponentObject *compObj = [super.viewC addVectors:tessObjs desc:@{kMaplyColor: _color,
+                                                                            kMaplyShader: kMaplyShaderDefaultLine,
                                                                            kMaplyFilled: @(YES),
                                                                            kMaplyDrawPriority: @(self.drawPriority)
                                                                            } mode:MaplyThreadCurrent];


### PR DESCRIPTION
Choose backface shader for polys.  e.g. for AutoTester Vector Style test.
