### PR TITLE
Fix Xcode 9.3 compilation issues

### DIFF
--- a/WhirlyGlobeSrc/local_libs/KissXML/DDXMLDocument.m
+++ b/WhirlyGlobeSrc/local_libs/KissXML/DDXMLDocument.m
@@ -1,5 +1,6 @@
 #import "DDXMLPrivate.h"
 #import "NSString+DDXML.h"
+#import <libxml/parser.h>
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).

--- a/WhirlyGlobeSrc/local_libs/aaplus/AADynamicalTime.cpp
+++ b/WhirlyGlobeSrc/local_libs/aaplus/AADynamicalTime.cpp
@@ -619,7 +619,7 @@ const DeltaTValue g_DeltaTValues[] =
   { 2457813.5,  68.6671 }, //1 March 2017
   { 2457844.5,  68.7135 }, //1 April 2017
   { 2457874.5,  68.7623 }, //1 May 2017
-  { 2457905.5,  68.8033 } //1 June 2017
+  { 2457905.5,  68.8033 }, //1 June 2017
 
 //All these final values are predicted values from Year 2015.25 to Year 2024.0 are taken from http://maia.usno.navy.mil/ser7/deltat.preds
   { 2457937.00, 69      }, //2017.5


### PR DESCRIPTION
When building this library with Xcode 9.3 we get this error:
`Implicit declaration of function 'xmlKeepBlanksDefault' is invalid`

Seems to be fixed by additional import statement in `DDXMLDocument.m`

Also typo fix for missing coma.