### PR TITLE
Fixed a bug where caching sometimes doesn't work

### DIFF
--- a/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyRemoteTileSource.mm
+++ b/WhirlyGlobeSrc/WhirlyGlobe-MaplyComponent/src/MaplyRemoteTileSource.mm
@@ -353,6 +353,8 @@ static bool trackConnections = false;
 {
     if ([_tileInfo isKindOfClass:[MaplyRemoteTileSource class]])
         return ((MaplyRemoteTileSource *)_tileInfo).cacheDir;
+    else if ([_tileInfo isKindOfClass:[MaplyRemoteTileSource class]])
+        return ((MaplyRemoteTileInfo *)_tileInfo).cacheDir;
     else
         return nil;
 }
@@ -361,6 +363,8 @@ static bool trackConnections = false;
 {
     if ([_tileInfo isKindOfClass:[MaplyRemoteTileSource class]])
         [(MaplyRemoteTileSource *)_tileInfo setCacheDir:cacheDir];
+    else if ([_tileInfo isKindOfClass:[MaplyRemoteTileInfo class]])
+        [(MaplyRemoteTileInfo *)_tileInfo setCacheDir: cacheDir];
 }
 
 - (int)minZoom


### PR DESCRIPTION
In our project, we instantiate our tile layer with a `MapRemoteTileSource`:

```
guard let tileSource = MaplyRemoteTileSource(baseURL: viewModel.mapTileSource, ext: nil, minZoom: 0, maxZoom: maxZoom) else { return }

tileSource.cacheDir = tilesCacheDirectory

guard let tileLayer: MaplyQuadImageTilesLayer = MaplyQuadImageTilesLayer(coordSystem: tileSource.coordSys, tileSource: tileSource) else { return }

whirlyViewController.add(tileLayer)
...
```

WhirlyGlobe was not using `tilesCacheDirectory` as a cache directory (it was not caching at all). This pull request fixes that.