### PR TITLE
New Clustering Appearance

### DIFF
--- a/ios/library/WhirlyGlobe-MaplyComponent/include/MaplyCluster.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/MaplyCluster.h
@@ -70,6 +70,8 @@
     Generate a cluster group for a given collection of markers.
     
     Generate an image and size to represent the number of marker/labels we're consolidating.
+ 
+    @note Will not be called if @c -showMarkerWithHighestImportance returns @c true.
   */
 - (MaplyClusterGroup *__nonnull) makeClusterGroup:(MaplyClusterInfo *__nonnull)clusterInfo;
 
@@ -86,6 +88,9 @@
 /// The size of the cluster that will be created.
 /// This is the biggest cluster you're likely to create.  We use it to figure overlaps between clusters.
 - (CGSize) clusterLayoutSize;
+
+/// Use appearance and coordinate of cluster group marker with highest importance. If not set then an average of coordinates will be used
+- (bool) showMarkerWithHighestImportance;
 
 /// Set this if you want cluster to be user selectable.  On by default.
 - (bool) selectable;
@@ -119,6 +124,9 @@
 /// The size of the cluster that will be created.
 /// This is the biggest cluster you're likely to create.  We use it to figure overlaps between clusters.
 @property (nonatomic) CGSize clusterLayoutSize;
+
+/// Set to use appearance and coordinate of cluster group marker with highest importance. Off by default.
+@property (nonatomic) bool showMarkerWithHighestImportance;
 
 /// Set this if you want cluster to be user selectable.  On by default.
 @property (nonatomic) bool selectable;

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/MaplyBaseInteractionLayer.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/MaplyBaseInteractionLayer.mm
@@ -1070,6 +1070,8 @@ public:
     
     retObj.setWorldLoc(topObject->obj.getWorldLoc());
     retObj.setDrawPriority(topObject->obj.getDrawPriority());
+    if (topObject->obj.hasRotation())
+        retObj.setRotation(topObject->obj.getRotation());
     
     std::vector<ScreenSpaceObject::ConvexGeometry> allGeometry = topObject->obj.getGeometry();
     

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/MaplyBaseInteractionLayer.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/MaplyBaseInteractionLayer.mm
@@ -1047,6 +1047,44 @@ public:
     if (!clusterGen)
         return;
     
+    
+    if ([clusterGen showMarkerWithHighestImportance])
+    {
+        [self setupLayoutObject:retObj asBestOfLayoutObjects:layoutObjects];
+    } else {
+        [self setupLayoutObject:retObj asAverageOfLayoutObjects:layoutObjects withClusterGenerator:clusterGen];
+    }
+}
+
+- (void)setupLayoutObject:(LayoutObject &)retObj asBestOfLayoutObjects:(const std::vector<LayoutObjectEntry *> &)layoutObjects
+{
+    LayoutObjectEntry *topObject = nullptr;
+    LayoutEntrySorter sorter;
+    
+    for (auto obj : layoutObjects)
+        if (topObject == nullptr || sorter(obj, topObject))
+            topObject = obj;
+    
+    if (topObject == nullptr || topObject->obj.getGeometry().empty())
+        return;
+    
+    retObj.setWorldLoc(topObject->obj.getWorldLoc());
+    retObj.setDrawPriority(topObject->obj.getDrawPriority());
+    
+    std::vector<ScreenSpaceObject::ConvexGeometry> allGeometry = topObject->obj.getGeometry();
+    
+    if (allGeometry.empty())
+        return;
+    
+    retObj.layoutPts = allGeometry.back().coords;
+    retObj.selectPts = allGeometry.back().coords;
+    
+    for (auto geometry : allGeometry)
+        retObj.addGeometry(geometry);
+}
+
+- (void)setupLayoutObject:(LayoutObject &)retObj asAverageOfLayoutObjects:(const std::vector<LayoutObjectEntry *> &)layoutObjects withClusterGenerator:(NSObject<MaplyClusterGenerator> *)clusterGen
+{
     // Pick a representive screen object
     int drawPriority = -1;
     LayoutObject *sampleObj = NULL;

--- a/ios/library/WhirlyGlobeLib/include/LayoutManager.h
+++ b/ios/library/WhirlyGlobeLib/include/LayoutManager.h
@@ -157,6 +157,18 @@ public:
     // Pointer into cluster parameters
     int clusterParamID;
 };
+    
+// Sort more important things to the front
+typedef struct
+{
+    bool operator () (const LayoutObjectEntry *a,const LayoutObjectEntry *b) const
+    {
+        if (a->obj.importance == b->obj.importance)
+            return a > b;
+        return a->obj.importance > b->obj.importance;
+    }
+} LayoutEntrySorter;
+typedef std::set<LayoutObjectEntry *,LayoutEntrySorter> LayoutSortingSet;
 
 /** The layout manager handles 2D text and marker layout.  We feed it objects
     we want to be drawn and it will figure out which ones should be visible

--- a/ios/library/WhirlyGlobeLib/include/ScreenSpaceBuilder.h
+++ b/ios/library/WhirlyGlobeLib/include/ScreenSpaceBuilder.h
@@ -202,12 +202,14 @@ public:
     int getDrawPriority() { return state.drawPriority; }
     void setKeepUpright(bool keepUpright);
     void setRotation(double rotation);
+    double getRotation() const { return rotation; }
+    bool hasRotation() const { return state.rotation; };
     void setFade(NSTimeInterval fadeUp,NSTimeInterval fadeDown);
     void setOffset(const Point2d &offset);
     void setPeriod(NSTimeInterval period);
     
     void addGeometry(const ConvexGeometry &geom);
-    std::vector<ConvexGeometry> getGeometry() { return geometry; }
+    std::vector<ConvexGeometry> getGeometry() const { return geometry; }
     
     // Get a program ID either from the drawable state or geometry
     SimpleIdentity getTypicalProgramID();

--- a/ios/library/WhirlyGlobeLib/include/ScreenSpaceBuilder.h
+++ b/ios/library/WhirlyGlobeLib/include/ScreenSpaceBuilder.h
@@ -207,6 +207,7 @@ public:
     void setPeriod(NSTimeInterval period);
     
     void addGeometry(const ConvexGeometry &geom);
+    std::vector<ConvexGeometry> getGeometry() { return geometry; }
     
     // Get a program ID either from the drawable state or geometry
     SimpleIdentity getTypicalProgramID();

--- a/ios/library/WhirlyGlobeLib/src/LayoutManager.mm
+++ b/ios/library/WhirlyGlobeLib/src/LayoutManager.mm
@@ -186,18 +186,6 @@ bool LayoutManager::hasChanges()
     
     return ret;
 }
-    
-// Sort more important things to the front
-typedef struct
-{
-    bool operator () (const LayoutObjectEntry *a,const LayoutObjectEntry *b) const
-    {
-        if (a->obj.importance == b->obj.importance)
-            return a > b;
-        return a->obj.importance > b->obj.importance;
-    }
-} LayoutEntrySorter;
-typedef std::set<LayoutObjectEntry *,LayoutEntrySorter> LayoutSortingSet;
 
 // Return the screen space objects in a form the selection manager can understand
 void LayoutManager::getScreenSpaceObjects(const SelectionManager::PlacementInfo &pInfo,std::vector<ScreenSpaceObjectLocation> &screenSpaceObjs)


### PR DESCRIPTION
A new method of clustering in BaseInteractionLayer controlled by instances of MaplyClusterGenerator
Allows showing a single representative member from each cluster group instead of an abstract marker in average location.