### PR TITLE
Fix issue with nil data when acceptFailures option enabled.

### DIFF
--- a/ios/library/WhirlyGlobe-MaplyComponent/src/MaplyMultiplexTileSource.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/MaplyMultiplexTileSource.mm
@@ -377,7 +377,7 @@ static bool trackConnections = false;
         // Let the paging layer know about it
         NSMutableArray *allData = [NSMutableArray array];
         if (singleFetch)
-            [allData addObject:tileData];
+            [allData addObject:(tileData ? tileData : [NSNull null])];
         else
             for (unsigned int ii=0;ii<theTile.tileData.size();ii++)
                 [allData addObject:theTile.tileData[ii]];


### PR DESCRIPTION
Currently, it crashes when accept failures option is true. This small fix with checking whether the tileData object is nil.