### PR TITLE
Keep attributes of vector object during creation a vector tile marker

### DIFF
--- a/android/library/maply/src/main/java/com/mousebird/maply/VectorTileMarkerStyle.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/VectorTileMarkerStyle.java
@@ -56,6 +56,9 @@ public class VectorTileMarkerStyle extends VectorTileStyle {
                 marker.loc = centroid;
                 marker.size = new Point2d(32, 32);
                 marker.selectable = true;
+
+                setAttributes(marker, vector);
+
                 markers.add(marker);
             }
         }
@@ -67,4 +70,11 @@ public class VectorTileMarkerStyle extends VectorTileStyle {
         return null;
     }
 
+    private void setAttributes(ScreenMarker marker, VectorObject vectorObject) {
+        AttrDictionary attributes = vectorObject.getAttributes();
+        AttrDictionary markerAttributes = new AttrDictionary();
+
+        markerAttributes.addEntries(attributes);
+        marker.userObject = markerAttributes;
+    }
 }


### PR DESCRIPTION
When vector objects created from GeoJson are rendered with SLD styles, their attributes are ignored. This PR helps to keep vector object attributes during creation a screen marker from it. 