### PR TITLE
Feature/external control min height above surface

### DIFF
--- a/android/library/Android/jni/MapView_jni.cpp
+++ b/android/library/Android/jni/MapView_jni.cpp
@@ -148,6 +148,24 @@ JNIEXPORT jdouble JNICALL Java_com_mousebird_maply_MapView_minHeightAboveSurface
     return 0.0;
 }
 
+JNIEXPORT void JNICALL Java_com_mousebird_maply_MapView_setMinHeightAboveSurface
+  (JNIEnv *env, jobject obj, jdouble minHeightAboveSurface)
+{
+	try
+	{
+		MapViewClassInfo *classInfo = MapViewClassInfo::getClassInfo();
+		Maply::MapView *view = classInfo->getObject(env,obj);
+		if (!view)
+			return;
+
+		return view->setMinHeightAboveSurface(minHeightAboveSurface);
+	}
+	catch (...)
+	{
+		__android_log_print(ANDROID_LOG_VERBOSE, "Maply", "Crash in MapView::setMinHeightAboveSurface()");
+	}
+}
+
 JNIEXPORT jdouble JNICALL Java_com_mousebird_maply_MapView_maxHeightAboveSurface
   (JNIEnv *env, jobject obj)
 {

--- a/android/library/Android/jni/com_mousebird_maply_MapView.h
+++ b/android/library/Android/jni/com_mousebird_maply_MapView.h
@@ -33,6 +33,14 @@ JNIEXPORT jdouble JNICALL Java_com_mousebird_maply_MapView_minHeightAboveSurface
 
 /*
  * Class:     com_mousebird_maply_MapView
+ * Method:    setMinHeightAboveSurface
+ * Signature: (D)V
+ */
+JNIEXPORT void JNICALL Java_com_mousebird_maply_MapView_setMinHeightAboveSurface
+  (JNIEnv *, jobject, jdouble);
+
+/*
+ * Class:     com_mousebird_maply_MapView
  * Method:    maxHeightAboveSurface
  * Signature: ()D
  */

--- a/android/library/Android/src/com/mousebird/maply/MapController.java
+++ b/android/library/Android/src/com/mousebird/maply/MapController.java
@@ -296,6 +296,14 @@ public class MapController extends MaplyBaseController implements View.OnTouchLi
 	}
 
 	/**
+	 * Set minimal allowed height above surface
+	 * @param minHeightAboveSurface
+	 */
+	public void setMinHeightAboveSurface(double minHeightAboveSurface) {
+		mapView.setMinHeightAboveSurface(minHeightAboveSurface);
+	}
+
+	/**
 	 * For a given position, how high do we have to be to see the given area.
 	 * <p>
 	 * Even for 2D maps we represent things in terms of height.

--- a/android/library/Android/src/com/mousebird/maply/MapGestureHandler.java
+++ b/android/library/Android/src/com/mousebird/maply/MapGestureHandler.java
@@ -89,6 +89,15 @@ public class MapGestureHandler
 	}
 
 	/**
+	 * Set minimal allowed height above surface
+	 *
+	 * @param minHeightAboveSurface
+	 */
+	public void setMinHeightAboveSurface(double minHeightAboveSurface) {
+		mapView.setMinHeightAboveSurface(minHeightAboveSurface);
+	}
+
+	/**
 	 * Check that a given position will be within the given bounds.
 	 * This is used by the various gestures for bounds checking.
 	 * 
@@ -198,7 +207,7 @@ public class MapGestureHandler
 				Point3d pos = maplyControl.mapView.getLoc();
 				mapView.cancelAnimation();
 				Point3d newPos = new Point3d(pos.getX(),pos.getY(),startZ*scale);
-				if (withinBounds(mapView,maplyControl.getViewSize(),newPos,maplyControl.viewBounds)) {
+				if (withinBounds(mapView,maplyControl.getViewSize(),newPos,maplyControl.viewBounds) || scale < 1.0) {
 					double newZ = newPos.getZ();
 					newZ = Math.min(newZ,zoomLimitMax);
 					newZ = Math.max(newZ,zoomLimitMin);

--- a/android/library/Android/src/com/mousebird/maply/MapGestureHandler.java
+++ b/android/library/Android/src/com/mousebird/maply/MapGestureHandler.java
@@ -207,7 +207,7 @@ public class MapGestureHandler
 				Point3d pos = maplyControl.mapView.getLoc();
 				mapView.cancelAnimation();
 				Point3d newPos = new Point3d(pos.getX(),pos.getY(),startZ*scale);
-				if (withinBounds(mapView,maplyControl.getViewSize(),newPos,maplyControl.viewBounds) || scale < 1.0) {
+				if (withinBounds(mapView,maplyControl.getViewSize(),newPos,maplyControl.viewBounds)) {
 					double newZ = newPos.getZ();
 					newZ = Math.min(newZ,zoomLimitMax);
 					newZ = Math.max(newZ,zoomLimitMin);

--- a/android/library/WhirlyGlobeLib/include/MaplyView.h
+++ b/android/library/WhirlyGlobeLib/include/MaplyView.h
@@ -61,6 +61,9 @@ public:
     /// Calculate the Z buffer resolution
     float calcZbufferRes();
 
+    /// Calculate image plane size
+    double calculateImagePlaneSize();
+
     /// Generate the model view matrix for use by OpenGL.
     virtual Eigen::Matrix4d calcModelMatrix();
     
@@ -78,6 +81,9 @@ public:
 
     /// Minimum valid height above plane
     double minHeightAboveSurface();
+
+    /// Set minimum valid height above plane
+    void setMinHeightAboveSurface(double minHeightAboveSurface);
 
     /// Maximum valid height above plane
     double maxHeightAboveSurface();

--- a/android/library/WhirlyGlobeLib/src/MaplyView.cpp
+++ b/android/library/WhirlyGlobeLib/src/MaplyView.cpp
@@ -194,6 +194,12 @@ double MapView::minHeightAboveSurface()
     return nearPlane;
 }
 
+void MapView::setMinHeightAboveSurface(double minHeightAboveSurface)
+{
+    nearPlane = minHeightAboveSurface;
+    imagePlaneSize = MapView::calculateImagePlaneSize();
+}
+
 double MapView::maxHeightAboveSurface()
 {
     return farPlane;

--- a/android/library/WhirlyGlobeLib/src/MaplyView.cpp
+++ b/android/library/WhirlyGlobeLib/src/MaplyView.cpp
@@ -32,7 +32,7 @@ MapView::MapView(WhirlyKit::CoordSystemDisplayAdapter *inCoordAdapter)
     coordAdapter = inCoordAdapter;
     fieldOfView = 60.0 / 360.0 * 2 * (float)M_PI;  // 60 degree field of view
     nearPlane = 0.00001;
-    imagePlaneSize = nearPlane * tanf(fieldOfView / 2.0);
+    imagePlaneSize = MapView::calculateImagePlaneSize();
     farPlane = 5.0;
     lastChangedTime = TimeGetCurrent();
     continuousZoom = false;
@@ -84,6 +84,11 @@ float MapView::calcZbufferRes()
     double delta = 0.0001;
     
     return delta;
+}
+
+double MapView::calculateImagePlaneSize()
+{
+   return nearPlane * tanf(fieldOfView / 2.0);
 }
 
 Eigen::Matrix4d MapView::calcModelMatrix()

--- a/android/library/maply/src/main/cpp/MapView_jni.cpp
+++ b/android/library/maply/src/main/cpp/MapView_jni.cpp
@@ -128,6 +128,24 @@ JNIEXPORT jobject JNICALL Java_com_mousebird_maply_MapView_getLoc
 	return NULL;
 }
 
+JNIEXPORT void JNICALL Java_com_mousebird_maply_MapView_setMinHeightAboveSurface
+  (JNIEnv *env, jobject obj, jdouble minHeightAboveSurface)
+{
+	try
+	{
+		MapViewClassInfo *classInfo = MapViewClassInfo::getClassInfo();
+		Maply::MapView *view = classInfo->getObject(env,obj);
+		if (!view)
+			return;
+
+		return view->setMinHeightAboveSurface(minHeightAboveSurface);
+	}
+	catch (...)
+	{
+		__android_log_print(ANDROID_LOG_VERBOSE, "Maply", "Crash in MapView::setMinHeightAboveSurface()");
+	}
+}
+
 JNIEXPORT jdouble JNICALL Java_com_mousebird_maply_MapView_minHeightAboveSurface
   (JNIEnv *env, jobject obj)
 {

--- a/android/library/maply/src/main/cpp/com_mousebird_maply_MapView.h
+++ b/android/library/maply/src/main/cpp/com_mousebird_maply_MapView.h
@@ -32,6 +32,15 @@ JNIEXPORT jdouble JNICALL Java_com_mousebird_maply_MapView_minHeightAboveSurface
   (JNIEnv *, jobject);
 
 /*
+* Class:     com_mousebird_maply_MapView
+* Method:    setMinHeightAboveSurface
+* Signature: (D)V
+*/
+JNIEXPORT void JNICALL Java_com_mousebird_maply_MapView_setMinHeightAboveSurface
+  (JNIEnv *, jobject, jdouble);
+
+
+/*
  * Class:     com_mousebird_maply_MapView
  * Method:    maxHeightAboveSurface
  * Signature: ()D

--- a/android/library/maply/src/main/java/com/mousebird/maply/MapController.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/MapController.java
@@ -306,6 +306,15 @@ public class MapController extends MaplyBaseController implements View.OnTouchLi
 	}
 
 	/**
+	 * Set minimal allowed height above surface
+	 *
+	 * @param minHeightAboveSurface
+	 */
+	public void setMinHeightAboveSurface(double minHeightAboveSurface) {
+		mapView.setMinHeightAboveSurface(minHeightAboveSurface);
+	}
+
+	/**
 	 * For a given position, how high do we have to be to see the given area.
 	 * <p>
 	 * Even for 2D maps we represent things in terms of height.

--- a/android/library/maply/src/main/java/com/mousebird/maply/MapGestureHandler.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/MapGestureHandler.java
@@ -89,6 +89,15 @@ public class MapGestureHandler
 	}
 
 	/**
+	 * Set minimal allowed height above surface
+	 *
+	 * @param minHeightAboveSurface
+	 */
+	public void setMinHeightAboveSurface(double minHeightAboveSurface) {
+		mapView.setMinHeightAboveSurface(minHeightAboveSurface);
+	}
+
+	/**
 	 * Check that a given position will be within the given bounds.
 	 * This is used by the various gestures for bounds checking.
 	 * 

--- a/android/library/maply/src/main/java/com/mousebird/maply/MapView.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/MapView.java
@@ -145,6 +145,8 @@ public class MapView extends View
 	native Point2d pointOnScreenFromPlane(Point3d pt,Matrix4d viewModelMatrix,Point2d frameSize);
 	// Minimum possible height above the surface
 	native double minHeightAboveSurface();
+	// Set minimum possible height above the surface
+	native void setMinHeightAboveSurface(double minHeightAboveSurface);
 	// Maximum possible height above the surface
 	native double maxHeightAboveSurface();
 	// Set the view location (including height)


### PR DESCRIPTION
This PR provides possibility to set min height above surface of MapView using MapController instance. 
The minHeightAboveSurface in MapView is set to 0.00001 what makes imposible to zoom closer.
Changing this value using `mapControl.setMinHeightAboveSurface(0.000001)` in MapFragment makes the map to zoom much closer. 
It fix for me #1159 