### PR TITLE
Prevent infinite results due to area coming out zero. 

### DIFF
--- a/common/WhirlyGlobeLib/include/OverlapHelper.h
+++ b/common/WhirlyGlobeLib/include/OverlapHelper.h
@@ -71,7 +71,7 @@ public:
     ClusterHelper(const Mbr &mbr,int sizeX, int sizeY, float resScale, const Point2d &clusterMarkerSize);
     
     // Add an object, possibly forming a group
-    void addObject(LayoutObjectEntry *objEntry,const Point2dVector pts);
+    void addObject(LayoutObjectEntry *objEntry,const Point2dVector &pts);
 
     // Deal with cluster to cluster overlap
     void resolveClusters();

--- a/common/WhirlyGlobeLib/include/VectorData.h
+++ b/common/WhirlyGlobeLib/include/VectorData.h
@@ -109,16 +109,26 @@ struct VectorShapeRefHash : std::hash<VectorShape*>
 typedef std::unordered_set<VectorShapeRef, VectorShapeRefHash, VectorShapeRefEqual> ShapeSet;
     
 /// Calculate area of a loop
-float CalcLoopArea(const VectorRing &);
-/// Calculate area of a loop
-double CalcLoopArea(const Point2dVector &);
+template <typename T> double CalcLoopArea(const std::vector<T,Eigen::aligned_allocator<T>>&);
+
 /// Calculate the centroid of a loop
-Point2f CalcLoopCentroid(const VectorRing &loop);
-/// Calculate the centroid of a bunch of points
-Point2d CalcLoopCentroid(const Point2dVector &loop);
+template <typename T> T CalcLoopCentroid(const std::vector<T,Eigen::aligned_allocator<T>>&);
+
+/// Calculate the centroid of a loop when the area is already known
+template <typename T> T CalcLoopCentroid(const std::vector<T,Eigen::aligned_allocator<T>>&, double loopArea);
+
 /// Calculate the center of mass of the points
-Point2d CalcCenterOfMass(const Point2dVector &loop);
-    
+template <typename T> T CalcCenterOfMass(const std::vector<T,Eigen::aligned_allocator<T>> &loop);
+
+extern template double CalcLoopArea<Point2f>(const VectorRing&);
+extern template double CalcLoopArea<Point2d>(const Point2dVector&);
+extern template Point2f CalcLoopCentroid(const VectorRing&);
+extern template Point2d CalcLoopCentroid(const Point2dVector&);
+extern template Point2f CalcLoopCentroid(const VectorRing&, double);
+extern template Point2d CalcLoopCentroid(const Point2dVector&, double);
+extern template Point2f CalcCenterOfMass(const VectorRing&);
+extern template Point2d CalcCenterOfMass(const Point2dVector&);
+
 /// Collection of triangles forming a mesh
 class VectorTriangles : public VectorShape
 {
@@ -260,8 +270,6 @@ protected:
     
 /// A set of strings
 typedef std::set<std::string> StringSet;
-    
-Point2d CalcCenterOfMass(const Point2dVector &loop);
     
 /// Break any edge longer than the given length.
 /// Returns true if it broke anything

--- a/common/WhirlyGlobeLib/src/OverlapHelper.cpp
+++ b/common/WhirlyGlobeLib/src/OverlapHelper.cpp
@@ -154,7 +154,7 @@ void ClusterHelper::findObjectsWithin(const Mbr &mbr,std::set<int> &objSet)
 }
 
 // Try to add an object.  Might fail (kind of the whole point).
-void ClusterHelper::addObject(LayoutObjectEntry *objEntry,const Point2dVector pts)
+void ClusterHelper::addObject(LayoutObjectEntry *objEntry,const Point2dVector &pts)
 {
     // We'll add this one way or another
     simpleObjects.resize(simpleObjects.size()+1);

--- a/common/WhirlyGlobeLib/src/VectorObject.cpp
+++ b/common/WhirlyGlobeLib/src/VectorObject.cpp
@@ -135,21 +135,21 @@ bool VectorObject::center(Point2d &center) const
 bool VectorObject::centroid(Point2d &centroid) const
 {
     // Find the loop with the largest area
-    float bigArea = -1.0;
-    const VectorRing *bigLoop = NULL;
+    float bigArea = 0.0;
+    const VectorRing *bigLoop = nullptr;
     for (const auto &shapeRef : shapes)
     {
         const auto shape = shapeRef.get();
-        const auto areal = dynamic_cast<const VectorAreal*>(shape);
-        if (areal && areal->loops.size() > 0)
-        {
-            for (unsigned int ii=0;ii<areal->loops.size();ii++)
-            {
-                const float area = std::abs(CalcLoopArea(areal->loops[ii]));
-                if (area > bigArea)
+        if (const auto areal = dynamic_cast<const VectorAreal*>(shape)) {
+            if (areal->loops.size() > 0) {
+                for (unsigned int ii=0;ii<areal->loops.size();ii++)
                 {
-                    bigLoop = &areal->loops[ii];
-                    bigArea = area;
+                    const float area = CalcLoopArea(areal->loops[ii]);
+                    if (std::abs(area) > std::abs(bigArea))
+                    {
+                        bigLoop = &areal->loops[ii];
+                        bigArea = area;
+                    }
                 }
             }
         } else if (const auto linear = dynamic_cast<const VectorLinear*>(shape)) {
@@ -170,9 +170,9 @@ bool VectorObject::centroid(Point2d &centroid) const
         }
     }
 
-    if (bigLoop && bigArea >= 0)    // TODO: >?
+    if (bigLoop && bigArea != 0)
     {
-        const Point2f centroid2f = CalcLoopCentroid(*bigLoop);
+        const Point2f centroid2f = CalcLoopCentroid(*bigLoop, bigArea);
         centroid.x() = centroid2f.x();
         centroid.y() = centroid2f.y();
         return true;


### PR DESCRIPTION
This should eliminate the +/-Inf results.  Most directly, the centroid of the largest loop was used even if the area was zero, leading to a divide-by-zero.

Previously, `centroid()` calculated the area to find the largest, then called `CalcLoopCentroid()` which calculated the area again.  Now there's a version that takes the known area so that doesn't need to be repeated.

These two were also inconsistent, in that one repeated the first point, assuming the loop was not closed, while the other did not.

The float/double versions have been collapsed into a template which is instantiated for each type to reduce duplicate code.  Doubles are also used for accumulators for both versions to avoid precision loss.

The previous version of `CalcLoopCentroid()` divided the computed area by two, then used it in the result as `.../(6*area)`.  It's not clear to my why this is, and I've simplified it to `.../(3*area)`.