### PR TITLE
Set debug/release options

### DIFF
--- a/android/library/maply/build.gradle
+++ b/android/library/maply/build.gradle
@@ -35,16 +35,36 @@ android {
 
         buildTypes {
             debug {
+                debuggable true
+                jniDebuggable true
                 ndk {
-                    abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86'
+                    abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
+                    debuggable true
+                }
+                externalNativeBuild {
+                    cmake {
+                        cppFlags "-O0", "-g", "-DDEBUG=1", "-DCMAKE_BUILD_TYPE=Debug"
+                    }
+                }
+            }
+            release {
+                debuggable false
+                jniDebuggable false
+                ndk {
+                    abiFilters 'arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64'
                     debuggable false
+                }
+                externalNativeBuild {
+                    cmake {
+                        cppFlags "-O2", "-DNDEBUG=1", "-DCMAKE_BUILD_TYPE=Release"
+                    }
                 }
             }
         }
 
         externalNativeBuild {
             cmake {
-                cppFlags "-frtti -fexceptions"
+                cppFlags "-frtti", "-fexceptions", "-std=gnu++14"
             }
         }
 


### PR DESCRIPTION
I noticed that `wkLogLevel(Debug,...` output wasn't showing up, and that's because `DEBUG` wasn't defined, despite the build variant being set to debug.  So I added separate debug and release sections to the gradle file with the appropriate options.

I also added x86-64 to the list, since x86 is less used these days.

I set `-O0` for debug mode which makes the code easier to debug by not eliminating/unrolling/etc. code.

And I set the language standard explicitly, since we currently can't build with c++17.
