### PR TITLE
Pass cancellation through JNI to vector tile parser.

### DIFF
--- a/android/library/maply/WhirlyGlobeLib/include/MapboxVectorStyleSet_Android.h
+++ b/android/library/maply/WhirlyGlobeLib/include/MapboxVectorStyleSet_Android.h
@@ -68,11 +68,12 @@ public:
     void cleanup(JNIEnv *env);
 
 public:
-    jobject thisObj;
-    jmethodID makeLabelInfoMethod;
-    jmethodID calculateTextWidthMethod;
-    jmethodID makeCircleTextureMethod;
-    jmethodID makeLineTextureMethod;
+    jobject thisObj = nullptr;
+    jmethodID makeLabelInfoMethod = nullptr;
+    jmethodID calculateTextWidthMethod = nullptr;
+    jmethodID makeCircleTextureMethod = nullptr;
+    jmethodID makeLineTextureMethod = nullptr;
+    jmethodID atomicBoolGetMethod = nullptr;
 
     // Map fontName/size to Java-side labelInfo objects
     std::map<std::pair<std::string, float>, LabelInfoAndroidRef> labelInfos;

--- a/android/library/maply/WhirlyGlobeLib/src/MapboxVectorStyleSet_Android.cpp
+++ b/android/library/maply/WhirlyGlobeLib/src/MapboxVectorStyleSet_Android.cpp
@@ -31,12 +31,7 @@ namespace WhirlyKit
 {
 
 MapboxVectorStyleSetImpl_Android::MapboxVectorStyleSetImpl_Android(Scene *scene,CoordSystem *coordSys,VectorStyleSettingsImplRef settings) :
-    MapboxVectorStyleSetImpl(scene,coordSys,std::move(settings)),
-    thisObj(nullptr),
-    makeLabelInfoMethod(nullptr),
-    makeCircleTextureMethod(nullptr),
-    makeLineTextureMethod(nullptr),
-    calculateTextWidthMethod(nullptr)
+    MapboxVectorStyleSetImpl(scene,coordSys,std::move(settings))
 {
 }
 
@@ -49,6 +44,11 @@ void MapboxVectorStyleSetImpl_Android::setupMethods(JNIEnv *env)
         calculateTextWidthMethod = env->GetMethodID(thisClass,"calculateTextWidth","(Ljava/lang/String;Lcom/mousebird/maply/LabelInfo;)D");
         makeCircleTextureMethod  = env->GetMethodID(thisClass,"makeCircleTexture", "(DIIFLcom/mousebird/maply/Point2d;)J");
         makeLineTextureMethod    = env->GetMethodID(thisClass,"makeLineTexture",   "([D)J");
+
+        if (auto cls = env->FindClass("java/util/concurrent/atomic/AtomicBoolean"))
+        {
+            atomicBoolGetMethod = env->GetMethodID(cls, "get", "()Z");
+        }
     }
 }
 

--- a/android/library/maply/WhirlyGlobeLib/src/QuadImageFrameLoader_Android.cpp
+++ b/android/library/maply/WhirlyGlobeLib/src/QuadImageFrameLoader_Android.cpp
@@ -1,9 +1,8 @@
-/*
- *  QuadImageFrameLoader_Android.cpp
+/*  QuadImageFrameLoader_Android.cpp
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 3/22/19.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "QuadImageFrameLoader_Android.h"
@@ -33,7 +31,7 @@ QIFBatchOps_Android::~QIFBatchOps_Android()
 {
 }
 
-QIFFrameAsset_Android::QIFFrameAsset_Android(PlatformInfo_Android *threadInfo,QuadFrameInfoRef frameInfo)
+QIFFrameAsset_Android::QIFFrameAsset_Android(PlatformInfo_Android *,QuadFrameInfoRef frameInfo)
 : QIFFrameAsset(frameInfo)
 {
 }
@@ -110,7 +108,7 @@ void QIFFrameAsset_Android::loadFailed(PlatformThreadInfo *threadInfo,QuadImageF
     clearRequestJava((PlatformInfo_Android *) threadInfo,(QuadImageFrameLoader_Android *)loader);
 }
 
-QIFTileAsset_Android::QIFTileAsset_Android(PlatformInfo_Android *threadInfo,const QuadTreeNew::ImportantNode &ident)
+QIFTileAsset_Android::QIFTileAsset_Android(PlatformInfo_Android *,const QuadTreeNew::ImportantNode &ident)
         : QIFTileAsset(ident)
 {
 }

--- a/android/library/maply/jni/include/generated/com_mousebird_maply_MapboxVectorTileParser.h
+++ b/android/library/maply/jni/include/generated/com_mousebird_maply_MapboxVectorTileParser.h
@@ -18,10 +18,10 @@ extern "C" {
 /*
  * Class:     com_mousebird_maply_MapboxVectorTileParser
  * Method:    parseDataNative
- * Signature: ([BLcom/mousebird/maply/VectorTileData;)Z
+ * Signature: ([BLcom/mousebird/maply/VectorTileData;Ljava/util/concurrent/atomic/AtomicBoolean;)Z
  */
 JNIEXPORT jboolean JNICALL Java_com_mousebird_maply_MapboxVectorTileParser_parseDataNative
-  (JNIEnv *, jobject, jbyteArray, jobject);
+  (JNIEnv *, jobject, jbyteArray, jobject, jobject);
 
 /*
  * Class:     com_mousebird_maply_MapboxVectorTileParser

--- a/android/library/maply/jni/include/generated/com_mousebird_maply_QuadLoaderBase.h
+++ b/android/library/maply/jni/include/generated/com_mousebird_maply_QuadLoaderBase.h
@@ -65,6 +65,14 @@ JNIEXPORT void JNICALL Java_com_mousebird_maply_QuadLoaderBase_cleanupNative
 
 /*
  * Class:     com_mousebird_maply_QuadLoaderBase
+ * Method:    setLoadReturn
+ * Signature: (Lcom/mousebird/maply/LoaderReturn;)V
+ */
+JNIEXPORT void JNICALL Java_com_mousebird_maply_QuadLoaderBase_setLoadReturn
+        (JNIEnv *env, jobject obj, jobject loadReturnObj);
+
+/*
+ * Class:     com_mousebird_maply_QuadLoaderBase
  * Method:    mergeLoaderReturn
  * Signature: (Lcom/mousebird/maply/LoaderReturn;Lcom/mousebird/maply/ChangeSet;)V
  */

--- a/android/library/maply/jni/src/quadLoading/QuadLoaderBase_jni.cpp
+++ b/android/library/maply/jni/src/quadLoading/QuadLoaderBase_jni.cpp
@@ -251,6 +251,27 @@ JNIEXPORT void JNICALL Java_com_mousebird_maply_QuadLoaderBase_cleanupNative
     }
 }
 
+//public native void setLoadReturn(long frameID,LoaderReturn loadReturn);
+extern "C"
+JNIEXPORT void JNICALL Java_com_mousebird_maply_QuadLoaderBase_setLoadReturn
+        (JNIEnv *env, jobject obj, jobject loadReturnObj)
+{
+    try
+    {
+        if (const auto loaderPtr = QuadImageFrameLoaderClassInfo::get(env,obj))
+        if (const auto loader = *loaderPtr)
+        if (const auto loadReturnPtr = LoaderReturnClassInfo::get(env,loadReturnObj))
+        if (const auto loadReturn = *loadReturnPtr)
+        {
+            loader->setLoadReturnRef(loadReturn->ident,loadReturn->frame,loadReturn);
+        }
+    }
+    catch (...)
+    {
+        __android_log_print(ANDROID_LOG_VERBOSE, "Maply", "Crash in QuadLoaderBase::setLoadReturn()");
+    }
+}
+
 extern "C"
 JNIEXPORT void JNICALL Java_com_mousebird_maply_QuadLoaderBase_mergeLoaderReturn
         (JNIEnv *env, jobject obj, jobject loadRetObj, jobject changeObj)

--- a/android/library/maply/src/main/java/com/mousebird/maply/BaseController.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/BaseController.java
@@ -885,6 +885,25 @@ public class BaseController implements RenderController.TaskManager, RenderContr
 		}
     }
 
+	/**
+	 * Add a runnable to be executed after the OpenGL surface is created.
+	 * If the runnable would be run immediately, delay it by delayMillisec instead.
+	 */
+	public void addPostSurfaceRunnable(Runnable run,long delayMillisec)
+	{
+		boolean runNow = false;
+		synchronized (this) {
+			if (rendererAttached)
+				runNow = true;
+			else
+				postSurfaceRunnables.add(run);
+		}
+		if (runNow) {
+			Handler handler = new Handler(activity.getMainLooper());
+			handler.postDelayed(run,delayMillisec);
+		}
+	}
+
 	int displayRate = 2;
 
 	/**

--- a/android/library/maply/src/main/java/com/mousebird/maply/MapboxVectorTileParser.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/MapboxVectorTileParser.java
@@ -20,7 +20,12 @@
 
 package com.mousebird.maply;
 
+import androidx.annotation.Nullable;
+
+import org.jetbrains.annotations.NotNull;
+
 import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This object parses Mapbox Vector Tile format one tile at a time.
@@ -31,7 +36,7 @@ import java.lang.ref.WeakReference;
 public class MapboxVectorTileParser
 {
     VectorStyleInterface styleDelegate = null;
-    VectorStyleWrapper vecStyleWrap = null;
+    //VectorStyleWrapper vecStyleWrap = null;
     WeakReference<RenderControllerInterface> viewC;
 
     private MapboxVectorTileParser() { }
@@ -39,7 +44,7 @@ public class MapboxVectorTileParser
     MapboxVectorTileParser(VectorStyleInterface inStyleDelegate,RenderControllerInterface inViewC)
     {
         styleDelegate = inStyleDelegate;
-        viewC = new WeakReference<RenderControllerInterface>(inViewC);
+        viewC = new WeakReference<>(inViewC);
 
         // If the style delegate is backed by a C++ object, we
         //  can just use that directly.
@@ -67,10 +72,24 @@ public class MapboxVectorTileParser
      */
     public boolean parseData(byte[] data,VectorTileData tileData)
     {
-        return parseDataNative(data, tileData);
+        return parseDataNative(data, tileData, null);
     }
 
-    native boolean parseDataNative(byte[] data,VectorTileData tileData);
+    /**
+     * Parse the data from a single tile.
+     * This returns a collection of vector objects in DataReturn.
+     *
+     * @param data The input data to parse.  You should have fetched this on your own.
+     * @param tileData A container for the data we parse and the styles create.
+     * @param cancel Cancellation signal, if set the parser will stop at the next feature
+     * @return Returns null on failure to parse.
+     */
+    public boolean parseData(@NotNull byte[] data, @NotNull VectorTileData tileData, @Nullable AtomicBoolean cancel)
+    {
+        return parseDataNative(data, tileData, cancel);
+    }
+
+    native boolean parseDataNative(@NotNull byte[] data,@NotNull VectorTileData tileData,@Nullable AtomicBoolean cancel);
 
     /// If set, we'll parse into local coordinates as specified by the bounding box, rather than geo coords
     native void setLocalCoords(boolean localCoords);

--- a/android/library/maply/src/main/java/com/mousebird/maply/QuadLoaderBase.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/QuadLoaderBase.java
@@ -1,9 +1,8 @@
-/*
- *  QuadLoaderBase.java
+/*  QuadLoaderBase.java
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 3/22/19.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 package com.mousebird.maply;
@@ -207,6 +205,11 @@ public class QuadLoaderBase implements QuadSamplingLayer.ClientInterface
         return null;
     }
 
+    /**
+     * Attach a LoaderReturn to the frame assets
+     */
+    public native void setLoadReturn(LoaderReturn loadReturn);
+
     protected boolean isShuttingDown = false;
 
     /**
@@ -338,8 +341,11 @@ public class QuadLoaderBase implements QuadSamplingLayer.ClientInterface
                     final LoaderReturn loadReturn = makeLoaderReturn();
                     loadReturn.setTileID(tileX, tileY, tileLevel);
                     loadReturn.setFrame(getFrameID(fFrame),fFrame);
+
                     if (data != null)
                         loadReturn.addTileData(data);
+
+                    loaderBase.setLoadReturn(loadReturn);
 
                     // We're on an AsyncTask in the background here, so do the loading
                     if (loadInterp != null)

--- a/android/library/maply/src/main/java/com/mousebird/maply/QuadPagingLoader.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/QuadPagingLoader.java
@@ -55,7 +55,7 @@ public class QuadPagingLoader extends QuadLoaderBase {
      * @param inInterp The loader interpreter takes input data (if any) per tile and turns it into visual objects
      * @param control The globe or map controller we're adding objects to.
      */
-    public QuadPagingLoader(final SamplingParams params,TileInfoNew inTileInfos[],LoaderInterpreter inInterp,BaseController control)
+    public QuadPagingLoader(final SamplingParams params,TileInfoNew[] inTileInfos,LoaderInterpreter inInterp,BaseController control)
     {
         super(control, params, 1, Mode.Object);
 

--- a/android/library/maply/src/main/java/com/mousebird/maply/RawPNGImageLoaderInterpreter.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/RawPNGImageLoaderInterpreter.java
@@ -19,8 +19,12 @@ public class RawPNGImageLoaderInterpreter implements LoaderInterpreter {
      */
     public void dataForTile(LoaderReturn loadReturn,QuadLoaderBase loader) {
         byte[][] images = loadReturn.getTileData();
-        for (byte[] image : images)
-            dataForTileNative(image,loadReturn);
+        for (byte[] image : images) {
+            if (loadReturn.isCanceled()) {
+                return;
+            }
+            dataForTileNative(image, loadReturn);
+        }
     }
 
     /**

--- a/common/WhirlyGlobeLib/include/MapboxVectorTileParser.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorTileParser.h
@@ -123,6 +123,10 @@ public:
     /// Returns false on failure or cancellation.
     virtual bool parse(PlatformThreadInfo *styleInst, RawData *rawData, VectorTileData *tileData, volatile bool *cancelBool);
 
+    /// Parse the vector tile and return a list of vectors.
+    /// Returns false on failure or cancellation.
+    virtual bool parse(PlatformThreadInfo *styleInst, RawData *rawData, VectorTileData *tileData, std::function<bool()> cancelFn);
+
     /// The subclass calls the appropriate style to build component objects
     ///  which are then returned in the VectorTileData
     virtual void buildForStyle(PlatformThreadInfo *styleInst,

--- a/common/WhirlyGlobeLib/include/QuadLoaderReturn.h
+++ b/common/WhirlyGlobeLib/include/QuadLoaderReturn.h
@@ -1,9 +1,8 @@
-/*
- *  QuadDisplayControllerNew.h
+/*  QuadLoaderReturn.h
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 2/14/19.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "WhirlyVector.h"

--- a/common/WhirlyGlobeLib/src/QuadLoaderReturn.cpp
+++ b/common/WhirlyGlobeLib/src/QuadLoaderReturn.cpp
@@ -1,9 +1,8 @@
-/*
- *  QuadDisplayControllerNew.cpp
+/*  QuadDisplayControllerNew.cpp
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 2/14/19.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "QuadLoaderReturn.h"
@@ -28,8 +26,9 @@ QuadFrameInfo::QuadFrameInfo()
 {
 }
     
-QuadLoaderReturn::QuadLoaderReturn(int generation)
-    : ident(0,0,0), cancel(false), hasError(false), generation(generation), frame(new QuadFrameInfo())
+QuadLoaderReturn::QuadLoaderReturn(int generation) :
+    ident(0,0,0), cancel(false), hasError(false),
+    generation(generation), frame(std::make_shared<QuadFrameInfo>())
 {
     frame->frameIndex = -1;
 }
@@ -37,7 +36,7 @@ QuadLoaderReturn::QuadLoaderReturn(int generation)
 QuadLoaderReturn::~QuadLoaderReturn()
 {
 }
-    
+
 void QuadLoaderReturn::clear()
 {
     cancel = true;

--- a/common/WhirlyGlobeLib/src/VectorTilePBFParser.cpp
+++ b/common/WhirlyGlobeLib/src/VectorTilePBFParser.cpp
@@ -1,10 +1,20 @@
-//
-//  VectorTilePBFParser.cpp
-//  WhirlyGlobeMaplyComponent
-//
-//  Created by Tim Sylvester on 10/30/20.
-//  Copyright © 2020 mousebird consulting. All rights reserved.
-//
+/*  VectorTilePBFParser.cpp
+ *  WhirlyGlobeLib
+ *
+ *  Created by Tim Sylvester on 10/30/20.
+ *  Copyright 2011-2021 mousebird consulting
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 
 #include "VectorTilePBFParser.h"
 

--- a/ios/library/WhirlyGlobeLib/src/QuadImageFrameLoader_iOS.mm
+++ b/ios/library/WhirlyGlobeLib/src/QuadImageFrameLoader_iOS.mm
@@ -1,9 +1,8 @@
-/*
- *  QuadImageFrameLoader_iOS.mm
+/*  QuadImageFrameLoader_iOS.mm
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 2/18/19.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "QuadImageFrameLoader_iOS.h"
@@ -64,9 +62,6 @@ void QIFFrameAsset_ios::clear(PlatformThreadInfo *threadInfo,QuadImageFrameLoade
     QIFBatchOps_ios *batchOps = (QIFBatchOps_ios *)inBatchOps;
     
     QIFFrameAsset::clear(threadInfo,loader,batchOps,changes);
-    
-    if (loadReturnRef)
-        loadReturnRef->cancel = true;
 
     if (request) {
         [batchOps->toCancel addObject:request];
@@ -204,7 +199,7 @@ QuadImageFrameLoader_ios::QuadImageFrameLoader_ios(const SamplingParams &params,
 void QuadImageFrameLoader_ios::setupFrames()
 {
     for (unsigned int ii=0;ii<[frameInfos count];ii++) {
-        QuadFrameInfoRef frame(new QuadFrameInfo());
+        auto frame = std::make_shared<QuadFrameInfo>();
         frame->frameIndex = ii;
         frames.push_back(frame);
     }
@@ -216,7 +211,7 @@ QuadImageFrameLoader_ios::~QuadImageFrameLoader_ios()
 
 QIFTileAssetRef QuadImageFrameLoader_ios::makeTileAsset(PlatformThreadInfo *threadInfo,const QuadTreeNew::ImportantNode &ident)
 {
-    auto tileAsset = QIFTileAssetRef(new QIFTileAsset_ios(ident));
+    auto tileAsset = std::make_shared<QIFTileAsset_ios>(ident);
     tileAsset->setupFrames(threadInfo,this,[frameInfos count]);
     return tileAsset;
 }


### PR DESCRIPTION
Check for cancellation throughout vector tile processing.
Fix a problem where the `LoaderReturn` was not set on QIF frames and so could not be marked as canceled.
Move loader return clearing down to shared `QIFFrameAsset::clear`

Mostly routine, except passing cancellation through JNI.  Booleans, etc., are immutable, so `AtomicBoolean` is a good fit, but it needs to be checked regularly, which is a bit ugly.