### PR TITLE
Fix incorrect use of a regular file which blocked cache directories

### DIFF
--- a/android/library/maply/src/main/java/com/mousebird/maply/RemoteTileFetcher.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/RemoteTileFetcher.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedInputStream;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -626,10 +627,16 @@ public class RemoteTileFetcher extends HandlerThread implements TileFetcher
     // Write to the local cache.  Called on a random thread.
     protected void writeToCache(TileInfo tile,byte[] data)
     {
-        if (tile.fetchInfo.cacheFile == null)
+        File cacheFile = tile.fetchInfo.cacheFile;
+        if (cacheFile == null)
             return;
 
-        try (OutputStream fOut = new FileOutputStream(tile.fetchInfo.cacheFile)) {
+        File parent = cacheFile.getParentFile();
+        if (!parent.isDirectory() && !parent.mkdirs()) {
+            return;
+        }
+
+        try (OutputStream fOut = new FileOutputStream(cacheFile)) {
             fOut.write(data);
         } catch (Exception e) {
             Log.w("RemoteTileFetcher", "Failed to write cache", e);


### PR DESCRIPTION
Create cache directories if necessary.
Load cached stylesheet directly, passing the file URI to okhttp causes an exception.
Accessing response bodies multiple times was producing no data, leading to nothing being cached.

A lot going on here.  Stylesheet/source caching wasn't actually working because `body.string()` "uses up" the input stream, so the later `body.bytes()` would produce nothing.  But that actually prevented a problem where, once the data is cached, the HTTP client refuses to load it from a file URI (Specifically, java.lang.IllegalArgumentException: Expected URL scheme 'http' or 'https' but was 'file'), I guess that's a feature of what we're using on iOS but not Android.