### PR TITLE
Topic/cancel fix

### DIFF
--- a/android/library/maply/jni/include/generated/com_mousebird_maply_QuadLoaderBase.h
+++ b/android/library/maply/jni/include/generated/com_mousebird_maply_QuadLoaderBase.h
@@ -73,6 +73,14 @@ JNIEXPORT void JNICALL Java_com_mousebird_maply_QuadLoaderBase_setLoadReturn
 
 /*
  * Class:     com_mousebird_maply_QuadLoaderBase
+ * Method:    clearLoadReturn
+ * Signature: (Lcom/mousebird/maply/LoaderReturn;)V
+ */
+JNIEXPORT void JNICALL Java_com_mousebird_maply_QuadLoaderBase_clearLoadReturn
+        (JNIEnv *env, jobject obj, jobject loadReturnObj);
+
+/*
+ * Class:     com_mousebird_maply_QuadLoaderBase
  * Method:    mergeLoaderReturn
  * Signature: (Lcom/mousebird/maply/LoaderReturn;Lcom/mousebird/maply/ChangeSet;)V
  */

--- a/common/WhirlyGlobeLib/src/LayoutManager.cpp
+++ b/common/WhirlyGlobeLib/src/LayoutManager.cpp
@@ -510,7 +510,7 @@ bool LayoutManager::runLayoutRules(PlatformThreadInfo *threadInfo,
             for (auto &obj : clusterHelper.simpleObjects)
                 if (obj.parentObject < 0)
                 {
-                    layoutObjs.push_back(LayoutObjectContainer(obj.objEntry));
+                    layoutObjs.emplace_back(obj.objEntry);
                     obj.objEntry->newEnable = true;
                     obj.objEntry->newCluster = -1;
                 }

--- a/common/WhirlyGlobeLib/src/QuadImageFrameLoader.cpp
+++ b/common/WhirlyGlobeLib/src/QuadImageFrameLoader.cpp
@@ -1088,17 +1088,22 @@ void QuadImageFrameLoader::mergeLoadedTile(PlatformThreadInfo *threadInfo,QuadLo
         wkLogLevel(Debug, "MaplyQuadImageLoader: Merging data from tile %d: (%d,%d)",loadReturn->ident.level,loadReturn->ident.x,loadReturn->ident.y);
 
     QuadTreeNew::Node ident(loadReturn->ident);
-    auto it = tiles.find(ident);
+    const auto it = tiles.find(ident);
+    const auto tile = (it != tiles.end()) ? it->second : nullptr;
+
     // Tile disappeared in the mean time, so drop it
-    if (it == tiles.end() || loadReturn->hasError) {
-        if (debugMode)
-            wkLogLevel(Debug,"MaplyQuadImageLoader: Failed to load tile before it was erased %d: (%d,%d)",loadReturn->ident.level,loadReturn->ident.x,loadReturn->ident.y);
+    if (!tile || loadReturn->hasError || loadReturn->cancel)
+    {
+        if (debugMode) {
+            wkLogLevel(Debug, "MaplyQuadImageLoader: "
+                       "Failed to load tile before it was erased %d: (%d,%d) (%stile,%serror,%scanceled)",
+                       loadReturn->ident.level, loadReturn->ident.x, loadReturn->ident.y,
+                       tile ? "" : "no ", loadReturn->hasError ? "" : "no ",loadReturn->cancel ? "" : "not ");
+        }
         failed = true;
     }
     
-    ImageTileRef image;
     std::vector<Texture *> texs;
-
     if (!failed) {
         // Build the texture(s)
         for (auto image : loadReturn->images) {
@@ -1120,14 +1125,13 @@ void QuadImageFrameLoader::mergeLoadedTile(PlatformThreadInfo *threadInfo,QuadLo
             // In object mode, we might not get anything, but it's not a failure
             failed = loadReturn->hasError;
         } else {
-            // In the images modes we need, ya know, and image
+            // In the images modes we need, ya know, an image
             failed = texs.empty();
         }
     }
 
     // If there is a tile, then notify it
-    if (it != tiles.end()) {
-        auto tile = it->second;
+    if (tile) {
         if (failed) {
             tile->frameFailed(threadInfo, this, loadReturn, changes);
         } else {
@@ -1148,8 +1152,7 @@ void QuadImageFrameLoader::mergeLoadedTile(PlatformThreadInfo *threadInfo,QuadLo
         for (auto compObj : loadReturn->ovlCompObjs)
             compObjs.insert(compObj->getId());
         compManager->removeComponentObjects(threadInfo, compObjs, changes);
-        loadReturn->compObjs.clear();
-        loadReturn->ovlCompObjs.clear();
+        loadReturn->clear();
     }
 }
     

--- a/common/WhirlyGlobeLib/src/QuadImageFrameLoader.cpp
+++ b/common/WhirlyGlobeLib/src/QuadImageFrameLoader.cpp
@@ -65,10 +65,11 @@ void QIFFrameAsset::setupFetch(QuadImageFrameLoader *loader)
 
 void QIFFrameAsset::clear(PlatformThreadInfo *threadInfo,QuadImageFrameLoader *loader,QIFBatchOps *batchOps,ChangeSet &changes) {
     state = Empty;
-    if (loadReturnRef) {
-        loadReturnRef->clear();
-        loadReturnRef.reset();
-    }
+
+    // Drop the reference to the loader return, its cancel flag can no longer be set.
+    // Note that we do not clear out its contents, they may still be needed to clean up.
+    loadReturnRef.reset();
+
     for (auto texID : texIDs)
         changes.push_back(new RemTextureReq(texID));
     texIDs.clear();


### PR DESCRIPTION
Key issue was that `QIFFrameAsset::clear` was dropping the component objects.

We also weren't checking for cancellation before switching threads and doing the merge, so that should make it a little more responsive.

And there was no way to clear the loader return reference from Java, though it turned out not to be needed.