### PR TITLE
Topic/more cancellation

### DIFF
--- a/android/library/maply/WhirlyGlobeLib/include/MapboxVectorStyleSet_Android.h
+++ b/android/library/maply/WhirlyGlobeLib/include/MapboxVectorStyleSet_Android.h
@@ -73,7 +73,6 @@ public:
     jmethodID calculateTextWidthMethod = nullptr;
     jmethodID makeCircleTextureMethod = nullptr;
     jmethodID makeLineTextureMethod = nullptr;
-    jmethodID atomicBoolGetMethod = nullptr;
 
     // Map fontName/size to Java-side labelInfo objects
     std::map<std::pair<std::string, float>, LabelInfoAndroidRef> labelInfos;

--- a/android/library/maply/WhirlyGlobeLib/include/VectorStyleSet_Android.h
+++ b/android/library/maply/WhirlyGlobeLib/include/VectorStyleSet_Android.h
@@ -51,8 +51,11 @@ public:
     virtual bool geomAdditive(PlatformThreadInfo *inst) override;
 
     /// Construct objects related to this style based on the input data.
-    virtual void buildObjects(PlatformThreadInfo *inst, const std::vector<VectorObjectRef> &vecObjs,
-                              const VectorTileDataRef &tileInfo, const Dictionary *desc) override;
+    virtual void buildObjects(PlatformThreadInfo *inst,
+                              const std::vector<VectorObjectRef> &vecObjs,
+                              const VectorTileDataRef &tileInfo,
+                              const Dictionary *desc,
+                              const CancelFunction &cancelFn) override;
 
 protected:
     SimpleIdentity uuid;  // ID of this style on the Java side
@@ -100,9 +103,14 @@ public:
     /// Called by the dispose on the JNI side
     void shutdown(PlatformThreadInfo *inst);
 
-public:
-    void buildObjects(PlatformThreadInfo *inst,SimpleIdentity styleID,const std::vector<VectorObjectRef> &vecObjs,
-                      const VectorTileDataRef &tileInfo, __unused const Dictionary *desc);
+    using CancelFunction = std::function<bool(PlatformThreadInfo *)>;
+
+    void buildObjects(PlatformThreadInfo *inst,
+                      SimpleIdentity styleID,
+                      const std::vector<VectorObjectRef> &vecObjs,
+                      const VectorTileDataRef &tileInfo,
+                      __unused const Dictionary *desc,
+                      const CancelFunction &cancelFn);
 
 protected:
 

--- a/android/library/maply/WhirlyGlobeLib/src/MapboxVectorStyleSet_Android.cpp
+++ b/android/library/maply/WhirlyGlobeLib/src/MapboxVectorStyleSet_Android.cpp
@@ -44,11 +44,6 @@ void MapboxVectorStyleSetImpl_Android::setupMethods(JNIEnv *env)
         calculateTextWidthMethod = env->GetMethodID(thisClass,"calculateTextWidth","(Ljava/lang/String;Lcom/mousebird/maply/LabelInfo;)D");
         makeCircleTextureMethod  = env->GetMethodID(thisClass,"makeCircleTexture", "(DIIFLcom/mousebird/maply/Point2d;)J");
         makeLineTextureMethod    = env->GetMethodID(thisClass,"makeLineTexture",   "([D)J");
-
-        if (auto cls = env->FindClass("java/util/concurrent/atomic/AtomicBoolean"))
-        {
-            atomicBoolGetMethod = env->GetMethodID(cls, "get", "()Z");
-        }
     }
 }
 

--- a/android/library/maply/jni/include/classInfo/Formats_jni.h
+++ b/android/library/maply/jni/include/classInfo/Formats_jni.h
@@ -1,9 +1,8 @@
-/*
- *  GeoJSON_jni.h
+/*  Formats_jni.h
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 3/7/19.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "Maply_jni.h"

--- a/android/library/maply/jni/include/classInfo/QuadLoading_jni.h
+++ b/android/library/maply/jni/include/classInfo/QuadLoading_jni.h
@@ -1,9 +1,8 @@
-/*
- *  QuadLoading_jni.h
+/*  QuadLoading_jni.h
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 3/20/19.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "Maply_jni.h"

--- a/android/library/maply/jni/include/generated/com_mousebird_maply_MapboxVectorTileParser.h
+++ b/android/library/maply/jni/include/generated/com_mousebird_maply_MapboxVectorTileParser.h
@@ -15,12 +15,13 @@ extern "C" {
 #define com_mousebird_maply_MapboxVectorTileParser_GeomTypeLineString 2L
 #undef com_mousebird_maply_MapboxVectorTileParser_GeomTypePolygon
 #define com_mousebird_maply_MapboxVectorTileParser_GeomTypePolygon 3L
+
 /*
  * Class:     com_mousebird_maply_MapboxVectorTileParser
- * Method:    parseDataNative
- * Signature: ([BLcom/mousebird/maply/VectorTileData;Ljava/util/concurrent/atomic/AtomicBoolean;)Z
+ * Method:    parseData
+ * Signature: ([BLcom/mousebird/maply/VectorTileData;Lcom/mousebird/maply/LoaderReturn;)Z
  */
-JNIEXPORT jboolean JNICALL Java_com_mousebird_maply_MapboxVectorTileParser_parseDataNative
+JNIEXPORT jboolean JNICALL Java_com_mousebird_maply_MapboxVectorTileParser_parseData
   (JNIEnv *, jobject, jbyteArray, jobject, jobject);
 
 /*

--- a/android/library/maply/jni/src/formats/MapboxVectorTileParser_jni.cpp
+++ b/android/library/maply/jni/src/formats/MapboxVectorTileParser_jni.cpp
@@ -20,6 +20,7 @@
 #import <Geometry_jni.h>
 #import <Vectors_jni.h>
 #import <Components_jni.h>
+#import <QuadLoading_jni.h>
 #import "WhirlyGlobe_Android.h"
 #import "com_mousebird_maply_MapboxVectorTileParser.h"
 
@@ -104,40 +105,28 @@ JNIEXPORT void JNICALL Java_com_mousebird_maply_MapboxVectorTileParser_setLocalC
     }
 }
 
+static bool noCancel(PlatformThreadInfo*) { return false; }
+
 extern "C"
-JNIEXPORT jboolean JNICALL Java_com_mousebird_maply_MapboxVectorTileParser_parseDataNative
-    (JNIEnv *env, jobject obj, jbyteArray data, jobject vecTileDataObj, jobject cancelObj)
+JNIEXPORT jboolean JNICALL Java_com_mousebird_maply_MapboxVectorTileParser_parseData
+    (JNIEnv *env, jobject obj, jbyteArray data, jobject vecTileDataObj, jobject loadRetObj)
 {
     try
     {
-        MapboxVectorTileParser *inst = MapboxVectorTileParserClassInfo::getClassInfo()->getObject(env,obj);
-        VectorTileDataRef *tileData = VectorTileDataClassInfo::getClassInfo()->getObject(env,vecTileDataObj);
+        const auto inst = MapboxVectorTileParserClassInfo::get(env,obj);
+        const auto tileDataPtr = VectorTileDataClassInfo::get(env,vecTileDataObj);
+        const auto tileData = tileDataPtr ? *tileDataPtr : nullptr;
         if (!inst || !tileData)
+        {
             return false;
-
-        std::function<bool()> cancelFn = [=](){return false;};
-
-        // Notify the style delegate of the new environment so it can make Java calls if need be
-        const auto style = inst->getStyleDelegate();
-        if (const auto theStyleDelegate = dynamic_cast<MapboxVectorStyleSetImpl_Android*>(style.get())) {
-            theStyleDelegate->setupMethods(env);
-            if (cancelObj && theStyleDelegate->atomicBoolGetMethod)
-            {
-                cancelFn = [=](){return env->CallBooleanMethod(cancelObj,theStyleDelegate->atomicBoolGetMethod);};
-            }
-        } else if (cancelObj) {
-            // The atomic bool class could theoretically be unloaded between calls, if no instances
-            // exist, so we can't store the ID statically.  We don't have a good place to keep it other
-            // than MapboxVectorStyleSetImpl_Android, so look it up once per cancel-able parse call.
-            if (auto cls = env->FindClass("java/util/concurrent/atomic/AtomicBoolean"))
-            if (auto method = env->GetMethodID(cls, "get", "()Z"))
-            {
-                cancelFn = [=](){return env->CallBooleanMethod(cancelObj,method);};
-            }
         }
 
-        // Need a pointer to this JNIEnv for low level parsing callbacks
-        PlatformInfo_Android platformInfo(env);
+        const auto loadRetPtr = LoaderReturnClassInfo::get(env,loadRetObj);
+        const auto loadRet = (loadRetPtr && *loadRetPtr) ? loadRetPtr->get() : nullptr;
+
+        using CancelFunction = MapboxVectorTileParser::CancelFunction;
+        const CancelFunction loadRetCancel = [=](auto){return loadRet->cancel;};
+        const auto cancelFn = loadRet ? loadRetCancel : noCancel;
 
         // Copy data into a temporary buffer (must we?)
         const int len = env->GetArrayLength(data);
@@ -146,8 +135,11 @@ JNIEXPORT jboolean JNICALL Java_com_mousebird_maply_MapboxVectorTileParser_parse
         {
             try
             {
+                // Need a pointer to this JNIEnv for low level parsing callbacks
+                PlatformInfo_Android platformInfo(env);
+
                 RawDataWrapper rawDataWrap(rawData, len, false);
-                ret = inst->parse(&platformInfo,&rawDataWrap,&**tileData,cancelFn);
+                ret = inst->parse(&platformInfo,&rawDataWrap,tileData.get(),cancelFn);
             }
             catch (...)
             {

--- a/android/library/maply/src/main/java/com/mousebird/maply/LayerThread.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/LayerThread.java
@@ -185,7 +185,7 @@ public class LayerThread extends HandlerThread implements View.ViewWatcher
 
 	// Used to shut down cleaning without cutting off outstanding work threads
 	public boolean isShuttingDown = false;
-	private Semaphore workLock = new Semaphore(1, true);
+	private final Semaphore workLock = new Semaphore(1, true);
 	private int numActiveWorkers = 0;
 
 	// Something is requesting a lock on shutting down while working

--- a/android/library/maply/src/main/java/com/mousebird/maply/MapboxKindaMap.kt
+++ b/android/library/maply/src/main/java/com/mousebird/maply/MapboxKindaMap.kt
@@ -14,7 +14,6 @@ import okhttp3.Response
 import java.io.*
 import java.lang.ref.WeakReference
 import java.net.URL
-import java.nio.file.Paths
 import kotlin.collections.ArrayList
 
 /**
@@ -206,8 +205,7 @@ open class MapboxKindaMap(
             try {
                 val cacheUrl = cacheResolve(resolvedURL)
                 if (cacheUrl.toString().startsWith("file:")) {
-                    val file = Paths.get(cacheUrl.toURI()).toFile()
-                    FileInputStream(file).use {
+                    FileInputStream(cacheUrl.file).use {
                         val json = it.bufferedReader().readText()
                         if (json.isNotEmpty()) {
                             styleSheetJSON = json
@@ -276,8 +274,7 @@ open class MapboxKindaMap(
             try {
                 val cacheUrl = cacheResolve(url)
                 if (cacheUrl.toString().startsWith("file:")) {
-                    val file = Paths.get(cacheUrl.toURI()).toFile()
-                    FileInputStream(file).use {
+                    FileInputStream(cacheUrl.file).use {
                         val json = it.bufferedReader().readText()
                         if (json.isNotEmpty()) {
                             processStylesheetJson(source, json)

--- a/android/library/maply/src/main/java/com/mousebird/maply/MapboxVectorTileParser.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/MapboxVectorTileParser.java
@@ -70,9 +70,9 @@ public class MapboxVectorTileParser
      * @param tileData A container for the data we parse and the styles create.
      * @return Returns null on failure to parse.
      */
-    public boolean parseData(byte[] data,VectorTileData tileData)
-    {
-        return parseDataNative(data, tileData, null);
+    public boolean parseData(@NotNull byte[] data,
+                             @NotNull VectorTileData tileData) {
+        return parseData(data,tileData,null);
     }
 
     /**
@@ -81,15 +81,11 @@ public class MapboxVectorTileParser
      *
      * @param data The input data to parse.  You should have fetched this on your own.
      * @param tileData A container for the data we parse and the styles create.
-     * @param cancel Cancellation signal, if set the parser will stop at the next feature
      * @return Returns null on failure to parse.
      */
-    public boolean parseData(@NotNull byte[] data, @NotNull VectorTileData tileData, @Nullable AtomicBoolean cancel)
-    {
-        return parseDataNative(data, tileData, cancel);
-    }
-
-    native boolean parseDataNative(@NotNull byte[] data,@NotNull VectorTileData tileData,@Nullable AtomicBoolean cancel);
+    public native boolean parseData(@NotNull byte[] data,
+                                    @NotNull VectorTileData tileData,
+                                    @Nullable LoaderReturn loadReturn);
 
     /// If set, we'll parse into local coordinates as specified by the bounding box, rather than geo coords
     native void setLocalCoords(boolean localCoords);

--- a/common/WhirlyGlobeLib/include/LabelManager.h
+++ b/common/WhirlyGlobeLib/include/LabelManager.h
@@ -118,6 +118,16 @@ public:
                              const std::vector<SingleLabelRef> &labels,
                              const LabelInfo &desc,ChangeSet &changes);
 
+    using CancelFunction = std::function<bool(PlatformThreadInfo *)>;
+    SimpleIdentity addLabels(PlatformThreadInfo *threadInfo,
+                             const std::vector<SingleLabelRef> &labels,
+                             const LabelInfo &desc,ChangeSet &changes,
+                             const CancelFunction& cancelFn);
+    SimpleIdentity addLabels(PlatformThreadInfo *threadInfo,
+                             const std::vector<SingleLabel *> &labels,
+                             const LabelInfo &desc,ChangeSet &changes,
+                             const CancelFunction& cancelFn);
+
     /// Change visual attributes (just the visibility range)
     void changeLabel(PlatformThreadInfo *threadInfo,
                      SimpleIdentity labelID,

--- a/common/WhirlyGlobeLib/include/LabelRenderer.h
+++ b/common/WhirlyGlobeLib/include/LabelRenderer.h
@@ -152,6 +152,12 @@ public:
 
     /// Renders the labels into a big texture and stores the resulting info
     void render(PlatformThreadInfo *threadInfo,const std::vector<SingleLabel *> &labels,ChangeSet &changes);
+
+    /// Renders the labels into a big texture and stores the resulting info
+    void render(PlatformThreadInfo *threadInfo,
+                const std::vector<SingleLabel *> &labels,
+                ChangeSet &changes,
+                const std::function<bool(PlatformThreadInfo*)>& cancelFn);
 };
 
 }

--- a/common/WhirlyGlobeLib/include/MapboxVectorStyleBackground.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorStyleBackground.h
@@ -1,9 +1,8 @@
-/*
- *  MapboxVectorStyleBackground.h
+/*  MapboxVectorStyleBackground.h
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 2/17/15.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "MapboxVectorStyleSetC.h"
@@ -54,7 +52,8 @@ public:
     virtual void buildObjects(PlatformThreadInfo *inst,
                               const std::vector<VectorObjectRef> &vecObjs,
                               const VectorTileDataRef &tileInfo,
-                              const Dictionary *desc) override;
+                              const Dictionary *desc,
+                              const CancelFunction &cancelFn) override;
 
     virtual RGBAColor getLegendColor(float zoom) const override {
         return paint.color ? paint.color->colorForZoom(zoom) : RGBAColor::clear();

--- a/common/WhirlyGlobeLib/include/MapboxVectorStyleCircle.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorStyleCircle.h
@@ -1,9 +1,8 @@
-/*
-*  MapboxVectorStyleCircle.h
+/* MapboxVectorStyleCircle.h
 *  WhirlyGlobe-MaplyComponent
 *
 *  Created by Steve Gifford on 2/17/15.
-*  Copyright 2011-2015 mousebird consulting
+*  Copyright 2011-2021 mousebird consulting
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
 *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
-*
 */
 
 #import "MapboxVectorStyleSetC.h"
@@ -63,7 +61,8 @@ public:
     virtual void buildObjects(PlatformThreadInfo *inst,
                               const std::vector<VectorObjectRef> &vecObjs,
                               const VectorTileDataRef &tileInfo,
-                              const Dictionary *desc) override;
+                              const Dictionary *desc,
+                              const CancelFunction &cancelFn) override;
 
     virtual void cleanup(PlatformThreadInfo *inst,ChangeSet &changes) override;
 

--- a/common/WhirlyGlobeLib/include/MapboxVectorStyleFill.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorStyleFill.h
@@ -49,7 +49,8 @@ public:
     virtual void buildObjects(PlatformThreadInfo *inst,
                               const std::vector<VectorObjectRef> &vecObjs,
                               const VectorTileDataRef &tileInfo,
-                              const Dictionary *desc) override;
+                              const Dictionary *desc,
+                              const CancelFunction &cancelFn) override;
     
     virtual void cleanup(PlatformThreadInfo *inst,ChangeSet &changes) override;
 

--- a/common/WhirlyGlobeLib/include/MapboxVectorStyleLayer.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorStyleLayer.h
@@ -68,7 +68,8 @@ public:
     virtual void buildObjects(PlatformThreadInfo *inst,
                               const std::vector<VectorObjectRef> &vecObjs,
                               const VectorTileDataRef &tileInfo,
-                              const Dictionary *desc) override = 0;
+                              const Dictionary *desc,
+                              const CancelFunction &cancelFn) override = 0;
     
     /// Clean up any objects (textures, probably)
     virtual void cleanup(PlatformThreadInfo *inst,ChangeSet &changes);

--- a/common/WhirlyGlobeLib/include/MapboxVectorStyleLine.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorStyleLine.h
@@ -69,7 +69,8 @@ public:
     virtual void buildObjects(PlatformThreadInfo *inst,
                               const std::vector<VectorObjectRef> &vecObjs,
                               const VectorTileDataRef &tileInfo,
-                              const Dictionary *desc) override;
+                              const Dictionary *desc,
+                              const CancelFunction &cancelFn) override;
     
     virtual void cleanup(PlatformThreadInfo *inst,ChangeSet &changes) override;
 

--- a/common/WhirlyGlobeLib/include/MapboxVectorStyleRaster.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorStyleRaster.h
@@ -1,9 +1,8 @@
-/*
- *  MapboxVectorStyleRaster.h
+/*  MapboxVectorStyleRaster.h
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 2/17/15.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "MapboxVectorStyleSetC.h"
@@ -38,7 +36,8 @@ public:
     virtual void buildObjects(PlatformThreadInfo *inst,
                               const std::vector<VectorObjectRef> &vecObjs,
                               const VectorTileDataRef &tileInfo,
-                              const Dictionary *desc) override;
+                              const Dictionary *desc,
+                              const CancelFunction &cancelFn) override;
     
     virtual void cleanup(PlatformThreadInfo *inst,ChangeSet &changes) override;
 

--- a/common/WhirlyGlobeLib/include/MapboxVectorStyleSymbol.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorStyleSymbol.h
@@ -105,7 +105,8 @@ public:
     virtual void buildObjects(PlatformThreadInfo *inst,
                               const std::vector<VectorObjectRef> &vecObjs,
                               const VectorTileDataRef &tileInfo,
-                              const Dictionary *desc) override;
+                              const Dictionary *desc,
+                              const CancelFunction &cancelFn) override;
     
     virtual void cleanup(PlatformThreadInfo *inst,ChangeSet &changes) override;
 

--- a/common/WhirlyGlobeLib/include/MapboxVectorTileParser.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorTileParser.h
@@ -1,9 +1,8 @@
-/*
- *  MapboxVectorTileParser.h
+/*  MapboxVectorTileParser.h
  *  WhirlyGlobeLib
  *
  *  Created by Steve Gifford on 5/25/16.
- *  Copyright 2011-2016 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "vector_tile.pb.h"

--- a/common/WhirlyGlobeLib/include/MapboxVectorTileParser.h
+++ b/common/WhirlyGlobeLib/include/MapboxVectorTileParser.h
@@ -123,16 +123,22 @@ public:
     /// Returns false on failure or cancellation.
     virtual bool parse(PlatformThreadInfo *styleInst, RawData *rawData, VectorTileData *tileData, volatile bool *cancelBool);
 
+    using CancelFunction = std::function<bool(PlatformThreadInfo *)>;
+
     /// Parse the vector tile and return a list of vectors.
     /// Returns false on failure or cancellation.
-    virtual bool parse(PlatformThreadInfo *styleInst, RawData *rawData, VectorTileData *tileData, std::function<bool()> cancelFn);
+    virtual bool parse(PlatformThreadInfo *styleInst,
+                       RawData *rawData,
+                       VectorTileData *tileData,
+                       const CancelFunction &cancelFn);
 
     /// The subclass calls the appropriate style to build component objects
     ///  which are then returned in the VectorTileData
     virtual void buildForStyle(PlatformThreadInfo *styleInst,
                                long long styleID,
                                const std::vector<VectorObjectRef> &vecObjs,
-                               const VectorTileDataRef &data);
+                               const VectorTileDataRef &data,
+                               const CancelFunction &cancelFn);
 
     /// Set the name of the uuid field.
     /// When present, the value is set as the kMaplyUUID attribute on generated objects

--- a/common/WhirlyGlobeLib/include/MaplyVectorStyleC.h
+++ b/common/WhirlyGlobeLib/include/MaplyVectorStyleC.h
@@ -171,11 +171,14 @@ public:
     /// Set if this geometry is additive (e.g. sticks around) rather than replacement
     virtual bool geomAdditive(PlatformThreadInfo *inst) = 0;
 
+    using CancelFunction = std::function<bool(PlatformThreadInfo *)>;
+
     /// Construct objects related to this style based on the input data.
     virtual void buildObjects(PlatformThreadInfo *inst,
                               const std::vector<VectorObjectRef> &vecObjs,
                               const VectorTileDataRef &tileInfo,
-                              const Dictionary *desc) = 0;
+                              const Dictionary *desc,
+                              const CancelFunction &cancelFn) = 0;
 };
 
 }

--- a/common/WhirlyGlobeLib/include/QuadImageFrameLoader.h
+++ b/common/WhirlyGlobeLib/include/QuadImageFrameLoader.h
@@ -32,8 +32,8 @@ class QuadImageFrameLoader;
 class QIFBatchOps
 {
 public:
-    QIFBatchOps();
-    virtual ~QIFBatchOps();
+    QIFBatchOps() = default;
+    virtual ~QIFBatchOps() = default;
 
     // Tiles we deleted for callback later
     std::vector<QuadTreeIdentifier> deletes;
@@ -46,13 +46,13 @@ public:
     typedef enum {Empty,Loaded,Loading} State;
     
     QIFFrameAsset(QuadFrameInfoRef frameInfo);
-    virtual ~QIFFrameAsset();
+    virtual ~QIFFrameAsset() = default;
     
     // What the frame is doing
     State getState();
     
     // Load priority
-    int getPriority();
+    int getPriority() const;
     
     // Texture ID (if loaded)
     const std::vector<SimpleIdentity> &getTexIDs();
@@ -124,13 +124,13 @@ class QIFTileAsset
 public:
     QIFTileAsset(const QuadTreeNew::ImportantNode &ident);
     void setupFrames(PlatformThreadInfo *threadInfo,QuadImageFrameLoader *loader,int numFrames);
-    virtual ~QIFTileAsset();
+    virtual ~QIFTileAsset() = default;
     
     typedef enum {Waiting,Active} State;
     
     State getState();
     
-    bool getShouldEnable();
+    bool getShouldEnable() const;
     void setShouldEnable(bool newVal);
     
     QuadTreeNew::ImportantNode getIdent();
@@ -293,7 +293,7 @@ public:
     // Number of tiles at the lowest level loaded for each frame
     std::vector<bool> topTilesLoaded;
     
-    bool hasUpdate(const std::vector<double> &curFrames);
+    bool hasUpdate(const std::vector<double> &curFrames) const;
     
     std::vector<double> lastCurFrames;
     TimeInterval lastRenderTime;
@@ -318,20 +318,20 @@ public:
     typedef enum {SingleFrame,MultiFrame,Object} Mode;
     
     QuadImageFrameLoader(const SamplingParams &params,Mode);
-    virtual ~QuadImageFrameLoader();
+    virtual ~QuadImageFrameLoader() = default;
     
     /// Add a focus
     void addFocus();
     
     /// Number of focus points (usually 1)
-    int getNumFocus();
+    int getNumFocus() const;
 
     /// Loading mode we're currently supporting
     Mode getMode();
     
     /// If set, we'll see way too much output
     void setDebugMode(bool newMode);
-    bool getDebugMode();
+    bool getDebugMode() const;
     
     typedef enum {Broad,Narrow} LoadMode;
     
@@ -340,7 +340,7 @@ public:
     LoadMode getLoadMode();
     
     /// True if there's loading going on, false if it's settled
-    bool getLoadingStatus();
+    bool getLoadingStatus() const;
     
     // Calculate the load priority for a given tile, respecting the rules
     int calcLoadPriority(const QuadTreeNew::ImportantNode &ident,int frame);
@@ -402,7 +402,7 @@ public:
     void setFlipY(bool newFlip);
     
     // Need to know how we're loading the tiles to calculate the render state
-    bool getFlipY();
+    bool getFlipY() const;
     
     /// Number of frames we're representing
     virtual int getNumFrames();
@@ -414,7 +414,7 @@ public:
     virtual void setFrames(const std::vector<QuadFrameInfoRef> &newFrames);
     
     /// Current generation of the loader (used for reload lagging)
-    int getGeneration();
+    int getGeneration() const;
     
     /// Reload the given frame (or everything)
     virtual void reload(PlatformThreadInfo *threadInfo,int frame, ChangeSet &changes);
@@ -526,7 +526,7 @@ public:
 
 protected:
     // Return a set of the active frames
-    virtual const std::set<QuadFrameInfoRef> getActiveFrames();
+    std::set<QuadFrameInfoRef> getActiveFrames();
 
     void updateLoadingStatus();
 

--- a/common/WhirlyGlobeLib/include/Scene.h
+++ b/common/WhirlyGlobeLib/include/Scene.h
@@ -351,7 +351,7 @@ public:
 //    dispatch_queue_t getDispatchQueue() { return dispatchQueue; }
     
     // Return all the drawables in a list.  Only call this on the main thread.
-    const std::vector<Drawable *> getDrawables() const;
+    std::vector<Drawable *> getDrawables() const;
     
     // Used for offline frame by frame rendering
     void setCurrentTime(TimeInterval newTime);
@@ -462,14 +462,14 @@ protected:
     
     /// Managers for various functionality
     std::map<std::string,SceneManagerRef> managers;
-                
+
     /// Lock for accessing programs
     mutable std::mutex programLock;
-                    
+
     // Sampling layers will set these to talk to shaders
     mutable std::mutex zoomSlotLock;
-    float zoomSlots[MaplyMaxZoomSlots];
-    
+    float zoomSlots[MaplyMaxZoomSlots] = {};
+
 protected:
     
     // If time is being set externally

--- a/common/WhirlyGlobeLib/include/VectorTilePBFParser.h
+++ b/common/WhirlyGlobeLib/include/VectorTilePBFParser.h
@@ -43,6 +43,8 @@ typedef std::shared_ptr<VectorObject> VectorObjectRef;
 class VectorTilePBFParser
 {
 public:
+    using CancelFunction = std::function<bool(PlatformThreadInfo *)>;
+
     VectorTilePBFParser(
         VectorTileData *tileData,
         VectorStyleDelegateImpl* styleData,
@@ -53,7 +55,7 @@ public:
         bool localCoords = false,
         bool parseAll = false,
         std::vector<VectorObjectRef>* keepVectors = nullptr,
-        std::function<bool()> isCancelled = [](){return false;});
+        CancelFunction isCancelled = [](auto){return false;});
 
     bool parse(const uint8_t* data, size_t length);
 
@@ -148,7 +150,7 @@ private:
     // Parsing methods
     inline bool processTags(const MutableDictionaryCRef &attributes, size_t tagIdx, size_t geomIdx, const Feature &feature);
     inline bool checkStyles(SimpleIDUSet& styleIDs, const MutableDictionaryCRef &attributes, const std::string &layerName);
-    inline void parseLineString(const uint32_t *geometry, size_t geomCount, ShapeSet& shapes);
+    inline void parseLineString(const uint32_t *geometry, size_t geomCount, ShapeSet& shapes) const;
     inline bool parsePolygon(const uint32_t *geometry, size_t geomCount, VectorAreal& shape);
     inline bool parsePoints(const uint32_t *geometry, size_t geomCount, VectorPoints& shape);
     inline void addFeature(const VectorObjectRef &vecObj, const SimpleIDUSet &styleIDs);
@@ -192,7 +194,7 @@ private:
     const bool _localCoords;
     const bool _parseAll;
     std::vector<VectorObjectRef>* _keepVectors = nullptr;
-    std::function<bool()> _checkCancelled;
+    CancelFunction _checkCancelled;
 
     // State used during parsing
     const MbrD _bbox;
@@ -216,7 +218,7 @@ private:
     bool _wasCancelled = false;
 
     // Constants
-    static constexpr int CmdBits = 3;
+    static constexpr uint32_t CmdBits = 3U;
     static constexpr int TileSize = 256;
     static constexpr double MAX_EXTENT = 20037508.342789244;
 };

--- a/common/WhirlyGlobeLib/src/DynamicTextureAtlas.cpp
+++ b/common/WhirlyGlobeLib/src/DynamicTextureAtlas.cpp
@@ -178,7 +178,7 @@ void DynamicTextureClearRegion::execute(Scene *scene,SceneRenderer *renderer,Vie
 DynamicTextureAddRegion::~DynamicTextureAddRegion()
 {
     if (!wasRun)
-        wkLogLevel(Error,"DynamicTextureAddRegion deleted without being run.");
+        wkLogLevel(Warn,"DynamicTextureAddRegion deleted without being run.");
 }
     
 void DynamicTextureAddRegion::execute(Scene *scene,SceneRenderer *renderer,View *view)

--- a/common/WhirlyGlobeLib/src/MapboxVectorStyleBackground.cpp
+++ b/common/WhirlyGlobeLib/src/MapboxVectorStyleBackground.cpp
@@ -66,7 +66,8 @@ bool MapboxVectorLayerBackground::parse(PlatformThreadInfo *inst,
 void MapboxVectorLayerBackground::buildObjects(PlatformThreadInfo *inst,
                                                const std::vector<VectorObjectRef> &vecObjs,
                                                const VectorTileDataRef &tileInfo,
-                                               const Dictionary *desc)
+                                               const Dictionary *desc,
+                                               const CancelFunction &)
 {
     const auto color = styleSet->backgroundColor(inst, tileInfo->ident.level);
     

--- a/common/WhirlyGlobeLib/src/MapboxVectorStyleCircle.cpp
+++ b/common/WhirlyGlobeLib/src/MapboxVectorStyleCircle.cpp
@@ -85,7 +85,8 @@ void MapboxVectorLayerCircle::cleanup(PlatformThreadInfo *inst,ChangeSet &change
 void MapboxVectorLayerCircle::buildObjects(PlatformThreadInfo *inst,
                                            const std::vector<VectorObjectRef> &vecObjs,
                                            const VectorTileDataRef &tileInfo,
-                                           const Dictionary *desc)
+                                           const Dictionary *desc,
+                                           const CancelFunction &cancelFn)
 {
     // If a representation is set, we produce results for non-visible layers
     if ((!visible  && (representation.empty() || repUUIDField.empty())) || circleTexID == EmptyIdentity)
@@ -118,6 +119,10 @@ void MapboxVectorLayerCircle::buildObjects(PlatformThreadInfo *inst,
     const auto emptyVal = std::make_pair(MarkerPtrVec(), VecObjRefVec());
     for (const auto &vecObj : vecObjs)
     {
+        if (cancelFn(inst))
+        {
+            return;
+        }
         if (vecObj->getVectorType() != VectorPointType)
         {
             continue;
@@ -168,6 +173,11 @@ void MapboxVectorLayerCircle::buildObjects(PlatformThreadInfo *inst,
 
     for (const auto &kvp : markersByUUID)
     {
+        if (cancelFn(inst))
+        {
+            return;
+        }
+
         const auto &uuid = kvp.first;
         const auto &markers = kvp.second.first;
         const auto &markerObjs = kvp.second.second;

--- a/common/WhirlyGlobeLib/src/MapboxVectorStyleFill.cpp
+++ b/common/WhirlyGlobeLib/src/MapboxVectorStyleFill.cpp
@@ -77,7 +77,8 @@ void MapboxVectorLayerFill::cleanup(PlatformThreadInfo *inst,ChangeSet &changes)
 void MapboxVectorLayerFill::buildObjects(PlatformThreadInfo *inst,
                                          const std::vector<VectorObjectRef> &vecObjs,
                                          const VectorTileDataRef &tileInfo,
-                                         const Dictionary *desc)
+                                         const Dictionary *desc,
+                                         const CancelFunction &cancelFn)
 {
     // If a representation is set, we produce results for non-visible layers
     if (!visible /*&& representation.empty()*/)
@@ -97,7 +98,7 @@ void MapboxVectorLayerFill::buildObjects(PlatformThreadInfo *inst,
 
     // Gather all the areal features for fill and/or outline
     std::vector<VectorShapeRef> shapes;
-    for (auto vecObj : vecObjs)
+    for (const auto& vecObj : vecObjs)
     {
         if (vecObj->getVectorType() == VectorArealType)
         {
@@ -112,6 +113,10 @@ void MapboxVectorLayerFill::buildObjects(PlatformThreadInfo *inst,
         std::vector<VectorShapeRef> tessShapes;
         for (const auto &it : shapes)
         {
+            if (cancelFn(inst))
+            {
+                return;
+            }
             if (const auto ar = dynamic_cast<VectorAreal*>(it.get()))
             {
                 const auto trisRef = VectorTriangles::createTriangles();

--- a/common/WhirlyGlobeLib/src/MapboxVectorStyleLine.cpp
+++ b/common/WhirlyGlobeLib/src/MapboxVectorStyleLine.cpp
@@ -123,7 +123,8 @@ void MapboxVectorLayerLine::cleanup(PlatformThreadInfo *inst,ChangeSet &changes)
 void MapboxVectorLayerLine::buildObjects(PlatformThreadInfo *inst,
                                          const std::vector<VectorObjectRef> &inVecObjs,
                                          const VectorTileDataRef &tileInfo,
-                                         const Dictionary *desc)
+                                         const Dictionary *desc,
+                                         const CancelFunction &cancelFn)
 {
     // If a representation is set, we produce results for non-visible layers
     if (!visible && (representation.empty() || repUUIDField.empty()))
@@ -236,6 +237,10 @@ void MapboxVectorLayerLine::buildObjects(PlatformThreadInfo *inst,
         {
             continue;
         }
+        if (cancelFn(inst))
+        {
+            return;
+        }
 
         const auto attrs = vecObj->getAttributes();
         const auto uuid = repUUIDField.empty() ? std::string() : attrs->getString(repUUIDField);
@@ -250,6 +255,11 @@ void MapboxVectorLayerLine::buildObjects(PlatformThreadInfo *inst,
 
     for (const auto &kvp : shapesByUUID)
     {
+        if (cancelFn(inst))
+        {
+            return;
+        }
+
         const auto &uuid = kvp.first;
         const auto &shapes = kvp.second;
 

--- a/common/WhirlyGlobeLib/src/MapboxVectorStyleRaster.cpp
+++ b/common/WhirlyGlobeLib/src/MapboxVectorStyleRaster.cpp
@@ -1,9 +1,8 @@
-/*
- *  MapboxVectorStyleRaster.mm
+/*  MapboxVectorStyleRaster.mm
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 2/17/15.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "MapboxVectorStyleRaster.h"
@@ -28,17 +26,14 @@ bool MapboxVectorLayerRaster::parse(PlatformThreadInfo *inst,
                                     const MapboxVectorStyleLayerRef &refLayer,
                                     int drawPriority)
 {
-    if (!MapboxVectorStyleLayer::parse(inst,styleEntry,refLayer,drawPriority))
-    {
-        return false;
-    }
-    return true;
+    return MapboxVectorStyleLayer::parse(inst, styleEntry, refLayer, drawPriority);
 }
 
-void MapboxVectorLayerRaster::buildObjects(PlatformThreadInfo *inst,
-                                           const std::vector<VectorObjectRef> &vecObjs,
-                                           const VectorTileDataRef &tileInfo,
-                                           const Dictionary *desc)
+void MapboxVectorLayerRaster::buildObjects(__unused PlatformThreadInfo *inst,
+                                           __unused const std::vector<VectorObjectRef> &vecObjs,
+                                           __unused const VectorTileDataRef &tileInfo,
+                                           __unused const Dictionary *desc,
+                                           __unused const CancelFunction &cancelFn)
 {
 }
 

--- a/common/WhirlyGlobeLib/src/MapboxVectorTileParser.cpp
+++ b/common/WhirlyGlobeLib/src/MapboxVectorTileParser.cpp
@@ -23,6 +23,7 @@
 #import "DictionaryC.h"
 #import "VectorTilePBFParser.h"
 
+#include <utility>
 #import <vector>
 
 using namespace Eigen;
@@ -128,17 +129,19 @@ static inline double secondsSince(const std::chrono::steady_clock::time_point &t
     return duration_cast<nanoseconds>(steady_clock::now() - t0).count() / 1.0e9;
 }
 
-static bool noCancel() { return false; }
+static bool noCancel(PlatformThreadInfo*) { return false; }
 
 bool MapboxVectorTileParser::parse(PlatformThreadInfo *styleInst, RawData *rawData,
                                    VectorTileData *tileData, volatile bool *cancelBool)
 {
-    const std::function<bool()> cancel = [=](){ return *cancelBool; };
+    const CancelFunction cancel = [=](auto){ return *cancelBool; };
     return parse(styleInst,rawData,tileData,cancelBool ? cancel : noCancel);
 }
 
-bool MapboxVectorTileParser::parse(PlatformThreadInfo *styleInst, RawData *rawData,
-                                   VectorTileData *tileData, std::function<bool()> cancelFn)
+bool MapboxVectorTileParser::parse(PlatformThreadInfo *styleInst,
+                                   RawData *rawData,
+                                   VectorTileData *tileData,
+                                   const CancelFunction &cancelFn)
 {
 //#if DEBUG
 //    wkLogLevel(Verbose, "MapboxVectorTileParser: Parse [%d/%d/%d] starting",
@@ -208,7 +211,12 @@ bool MapboxVectorTileParser::parse(PlatformThreadInfo *styleInst, RawData *rawDa
         auto styleData = std::make_shared<VectorTileData>(*tileData);
 
         // Ask the subclass to run the style and fill in the VectorTileData
-        buildForStyle(styleInst,it.first,vecs,styleData);
+        buildForStyle(styleInst,it.first,vecs,styleData,cancelFn);
+
+        if (cancelFn(styleInst))
+        {
+            return false;
+        }
 
         // Sort the results into categories if needed
         auto catIt = styleCategories.find(it.first);
@@ -278,12 +286,12 @@ bool MapboxVectorTileParser::parse(PlatformThreadInfo *styleInst, RawData *rawDa
 void MapboxVectorTileParser::buildForStyle(PlatformThreadInfo *styleInst,
                                            long long styleID,
                                            const std::vector<VectorObjectRef> &vecObjs,
-                                           const VectorTileDataRef &data)
-{
-    if (auto style = styleDelegate->styleForUUID(styleInst,styleID))
+                                           const VectorTileDataRef &data,
+                                           const CancelFunction &cancelFn)
     {
-        style->buildObjects(styleInst,vecObjs,data,nullptr);
+        if (auto style = styleDelegate->styleForUUID(styleInst,styleID))
+        {
+            style->buildObjects(styleInst,vecObjs,data,nullptr,cancelFn);
+        }
     }
-}
-    
 }

--- a/common/WhirlyGlobeLib/src/VectorTilePBFParser.cpp
+++ b/common/WhirlyGlobeLib/src/VectorTilePBFParser.cpp
@@ -35,9 +35,9 @@ namespace WhirlyKit
 
 namespace {
     // Fixed strings to avoid allocations on every call to, e.g., Dictionary::setString
-    const static std::string layerNameKey("layer_name");
-    const static std::string geometryTypeKey("geometry_type");
-    const static std::string layerOrderKey("layer_order");
+    const std::string layerNameKey("layer_name");       //NOLINT
+    const std::string geometryTypeKey("geometry_type"); //NOLINT
+    const std::string layerOrderKey("layer_order");     //NOLINT
 }
 
 const vector_tile_Tile_Layer VectorTilePBFParser::_defaultLayer = {
@@ -88,7 +88,7 @@ VectorTilePBFParser::VectorTilePBFParser(
         bool localCoords,
         bool parseAll,
         std::vector<VectorObjectRef>* keepVectors,
-        std::function<bool()> isCanceled)
+        CancelFunction isCanceled)
     : _tileData      (tileData)
     , _styleDelegate (styleData)
     , _styleInst     (styleInst)
@@ -98,7 +98,7 @@ VectorTilePBFParser::VectorTilePBFParser(
     , _localCoords   (localCoords)
     , _parseAll      (parseAll)
     , _keepVectors   (keepVectors)
-    , _checkCancelled(isCanceled)
+    , _checkCancelled(std::move(isCanceled))
     , _bbox          (tileData->bbox)
     , _bboxWidth     (_bbox.ur().x() - _bbox.ll().x())
     , _bboxHeight    (_bbox.ur().y() - _bbox.ll().y())
@@ -134,7 +134,8 @@ bool VectorTilePBFParser::layerDecode(pb_istream_t *stream, const pb_field_iter_
 
 bool VectorTilePBFParser::layerDecode(pb_istream_t *stream, const pb_field_iter_t *field)
 {
-    if (_checkCancelled()) {
+    if (_checkCancelled(_styleInst))
+    {
         _wasCancelled = true;
         return false;
     }
@@ -205,7 +206,8 @@ bool VectorTilePBFParser::layerDecode(pb_istream_t *stream, const pb_field_iter_
     size_t prevGeomIndex = 0;
     for (auto const &feature : _features)
     {
-        if (_checkCancelled()) {
+        if (_checkCancelled(_styleInst))
+        {
             _wasCancelled = true;
             return false;
         }
@@ -213,7 +215,7 @@ bool VectorTilePBFParser::layerDecode(pb_istream_t *stream, const pb_field_iter_
         auto attributes = std::make_shared<MutableDictionaryC>();
         attributes->setString(layerNameKey, layerName);
         attributes->setInt(geometryTypeKey, (int)feature.geomType);
-        attributes->setInt(layerOrderKey, _layerCount);
+        attributes->setInt(layerOrderKey, (int)_layerCount);
 
         const bool tagsOk = processTags(attributes, prevTagIndex, prevGeomIndex, feature);
         //const auto curTagIndex = prevTagIndex;
@@ -303,14 +305,14 @@ bool VectorTilePBFParser::layerDecode(pb_istream_t *stream, const pb_field_iter_
 /// https://github.com/mapbox/vector-tile-spec/tree/master/2.1/#432-parameter-integers
 /// A ParameterInteger is zigzag encoded so that small negative and positive values are both encoded as small integers.
 int32_t VectorTilePBFParser::decodeParamInt(int32_t p) {
-    return ((p >> 1) ^ (-(p & 1)));
+    return ((p >> 1U) ^ (-(p & 1U)));       //NOLINT these are right out of the spec
 }
 
 /// https://github.com/mapbox/vector-tile-spec/tree/master/2.1/#431-command-integers
 /// A command ID is encoded as an unsigned integer in the least significant 3 bits of the CommandInteger, and is in the range 0 through 7, inclusive.
 /// A command count is encoded as an unsigned integer in the remaining 29 bits of a CommandInteger, and is in the range 0 through pow(2, 29) - 1, inclusive.
 std::pair<uint8_t, int32_t> VectorTilePBFParser::decodeCommand(int32_t c) {
-    return std::make_pair(c & ((1 << CmdBits) - 1), c >> CmdBits);
+    return std::make_pair(c & ((1 << CmdBits) - 1), c >> CmdBits);  //NOLINT these are right out of the spec
 }
 
 // Layer contains a collection of Features
@@ -409,7 +411,7 @@ bool VectorTilePBFParser::checkStyles(SimpleIDUSet& styleIDs, const MutableDicti
     return (!styleIDs.empty() || _parseAll);
 }
 
-void VectorTilePBFParser::parseLineString(const uint32_t *geometry, size_t geomCount, ShapeSet& shapes)
+void VectorTilePBFParser::parseLineString(const uint32_t *geometry, size_t geomCount, ShapeSet& shapes) const
 {
     double x = 0;
     double y = 0;
@@ -448,7 +450,7 @@ void VectorTilePBFParser::parseLineString(const uint32_t *geometry, size_t geomC
 
                 if (cmd == SEG_MOVETO)  // move-to means we are starting a new segment
                 {
-                    if (lin && lin->pts.size() > 0)  // We've already got a line, finish it
+                    if (lin && !lin->pts.empty())  // We've already got a line, finish it
                     {
                         lin->initGeoMbr();
                         shapes.insert(lin);
@@ -462,7 +464,7 @@ void VectorTilePBFParser::parseLineString(const uint32_t *geometry, size_t geomC
             }
             else if (cmd == SEG_CLOSE_MASKED)
             {
-                if (lin->pts.size() > 0)  //We've already got a line, finish it
+                if (!lin->pts.empty())  //We've already got a line, finish it
                 {
                     lin->pts.emplace_back(firstCoord.x(),firstCoord.y());
                     lin->initGeoMbr();
@@ -485,7 +487,7 @@ void VectorTilePBFParser::parseLineString(const uint32_t *geometry, size_t geomC
         }
     }
     
-    if (lin && lin->pts.size() > 0)
+    if (lin && !lin->pts.empty())
     {
         lin->initGeoMbr();
         shapes.insert(lin);
@@ -540,7 +542,7 @@ bool VectorTilePBFParser::parsePolygon(const uint32_t *geometry, size_t geomCoun
             }
             else if (cmd == SEG_CLOSE_MASKED)
             {
-                if (ring.size() > 0)  //We've already got a line, finish it
+                if (!ring.empty())  //We've already got a line, finish it
                 {
                     ring.emplace_back(firstCoord.x(),firstCoord.y()); //close the loop
                     shape.loops.push_back(ring); //add loop to shape
@@ -555,12 +557,12 @@ bool VectorTilePBFParser::parsePolygon(const uint32_t *geometry, size_t geomCoun
     }
     
 #if DEBUG
-    if (ring.size() > 0)
+    if (!ring.empty())
     {
         wkLogLevel(Warn, "VectorTilePBFParser: Finished polygon loop, and ring has %d points", (int)ring.size());
     }
 #endif
-    //TODO: Is there a posibilty of still having a ring here that hasn't been added by a close command?
+    //TODO: Is there a possibility of still having a ring here that hasn't been added by a close command?
     
     if (!shape.loops.empty())
     {
@@ -676,12 +678,12 @@ bool VectorTilePBFParser::valueVecDecode(pb_istream_t *stream, const pb_field_it
     }
 
          if (value.has_float_value)  vec.push_back({{.floatValue  = value.float_value},  SmallValue::SmallValFloat});
-    else if (value.has_double_value) vec.push_back({{.doubleValue = value.double_value}, SmallValue::SmallValDouble});
-    else if (value.has_int_value)    vec.push_back({{.intValue    = value.int_value},    SmallValue::SmallValInt});
-    else if (value.has_uint_value)   vec.push_back({{.uintValue   = value.uint_value},   SmallValue::SmallValUInt});
-    else if (value.has_sint_value)   vec.push_back({{.sintValue   = value.sint_value},   SmallValue::SmallValSInt});
-    else if (value.has_bool_value)   vec.push_back({{.boolValue   = value.bool_value},   SmallValue::SmallValBool});
-    else                             vec.push_back({{.stringValue = string},             SmallValue::SmallValString});
+    else if (value.has_double_value) vec.push_back({{.doubleValue = value.double_value}, SmallValue::SmallValDouble});  //NOLINT
+    else if (value.has_int_value)    vec.push_back({{.intValue    = value.int_value},    SmallValue::SmallValInt});     //NOLINT
+    else if (value.has_uint_value)   vec.push_back({{.uintValue   = value.uint_value},   SmallValue::SmallValUInt});    //NOLINT
+    else if (value.has_sint_value)   vec.push_back({{.sintValue   = value.sint_value},   SmallValue::SmallValSInt});    //NOLINT
+    else if (value.has_bool_value)   vec.push_back({{.boolValue   = value.bool_value},   SmallValue::SmallValBool});    //NOLINT
+    else                             vec.push_back({{.stringValue = string},             SmallValue::SmallValString});  //NOLINT
 
     return true;
 }

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/loading/GeoJSONSource.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/loading/GeoJSONSource.h
@@ -1,10 +1,20 @@
-//
-//  GeoJSONSource.h
-//  AutoTester
-//
-//  Created by Ranen Ghosh on 2016-11-18.
-//  Copyright © 2016-2019 mousebird consulting.
-//
+/*  GeoJSONSource.mm
+ *  WhirlyGlobe-MaplyComponent
+ *
+ *  Created by Ranen Ghosh on 2016-11-18.
+ *  Copyright 2016-2021 mousebird consulting
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 
 #import <UIKit/UIKit.h>
 #import "control/MaplyBaseViewController.h"

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyVectorStyle_private.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyVectorStyle_private.h
@@ -169,7 +169,8 @@ public:
     virtual void buildObjects(PlatformThreadInfo *_Nullable inst,
                               const std::vector<VectorObjectRef> &vecObjs,
                               const VectorTileDataRef &tileData,
-                              const Dictionary *_Nullable desc) override;
+                              const Dictionary *_Nullable desc,
+                              const CancelFunction &) override;
 
 protected:
     NSObject<MaplyRenderControllerProtocol> *_Nullable  __weak viewC;

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyVectorStyle_private.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/private/MaplyVectorStyle_private.h
@@ -1,22 +1,20 @@
-/*
-*  MaplyVectorStyle_private.h
-*  WhirlyGlobe-MaplyComponent
-*
-*  Created by Steve Gifford on 1/3/14.
-*  Copyright 2011-2021 mousebird consulting
-*
-*  Licensed under the Apache License, Version 2.0 (the "License");
-*  you may not use this file except in compliance with the License.
-*  You may obtain a copy of the License at
-*  http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing, software
-*  distributed under the License is distributed on an "AS IS" BASIS,
-*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*  See the License for the specific language governing permissions and
-*  limitations under the License.
-*
-*/
+/*  MaplyVectorStyle_private.h
+ *  WhirlyGlobe-MaplyComponent
+ *
+ *  Created by Steve Gifford on 1/3/14.
+ *  Copyright 2011-2021 mousebird consulting
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 
 #import "MaplyVectorStyle.h"
 #import "WhirlyGlobe.h"
@@ -58,7 +56,13 @@
              forTile:(MaplyVectorTileData * __nonnull)tileData
                viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
                 desc:(NSDictionary * _Nullable)desc;
-;
+
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileData
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)desc
+            cancelFn:(bool(^__nullable)(void))cancelFn;
 
 @end
 

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorStyle.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorStyle.h
@@ -1,5 +1,4 @@
-/*
- *  MaplyVectorStyle.h
+/*  MaplyVectorStyle.h
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import <UIKit/UIKit.h>

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorStyle.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorStyle.h
@@ -147,6 +147,13 @@
                viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
                 desc:(NSDictionary * _Nullable)desc;
 
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileData
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)desc
+            cancelFn:(bool(^__nullable)(void))cancelFn;
+
 @end
 
 #ifdef __cplusplus

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorStyleSimple.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorStyleSimple.h
@@ -1,10 +1,20 @@
-//
-//  MaplyVectorStyleSimple.h
-//  WhirlyGlobe-MaplyComponent
-//
-//  Created by Steve Gifford on 3/15/16.
-//
-//
+/*  MaplyVectorStyleSimple.m
+ *  WhirlyGlobe-MaplyComponent
+ *
+ *  Created by Steve Gifford on 3/15/16.
+ *  Copyright 2011-2021 mousebird consulting
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 
 #import <Foundation/Foundation.h>
 #import "vector_tiles/MapboxVectorTiles.h"

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorTileLineStyle.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorTileLineStyle.h
@@ -1,9 +1,8 @@
-/*
- *  MaplyVectorLineStyle.h
+/*  MaplyVectorLineStyle.h
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "vector_styles/MaplyVectorStyle.h"

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorTileMarkerStyle.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorTileMarkerStyle.h
@@ -1,9 +1,8 @@
-/*
- *  MaplyVectorMarkerStyle.h
+/*  MaplyVectorMarkerStyle.h
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "vector_styles/MaplyVectorStyle.h"

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorTilePolygonStyle.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorTilePolygonStyle.h
@@ -1,9 +1,8 @@
-/*
- *  MaplyVectorPolygonStyle.h
+/*  MaplyVectorPolygonStyle.h
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "vector_styles/MaplyVectorStyle.h"

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorTileStyle.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorTileStyle.h
@@ -1,9 +1,8 @@
-/*
- *  MaplyVectorStyle.h
+/*  MaplyVectorTileStyle.h
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import <UIKit/UIKit.h>

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorTileTextStyle.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/vector_styles/MaplyVectorTileTextStyle.h
@@ -1,9 +1,8 @@
-/*
- *  MaplyVectorTextStyle.h
+/*  MaplyVectorTextStyle.h
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "vector_styles/MaplyVectorStyle.h"

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/loading/MaplyQuadImageLoader.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/loading/MaplyQuadImageLoader.mm
@@ -217,6 +217,9 @@ using namespace WhirlyKit;
     const auto __strong vc = loader.viewC;
     NSArray<id> *tileData = [loadReturn getTileData];
     for (unsigned int ii=0;ii<[tileData count];ii++) {
+        if (loadReturn.isCancelled) {
+            return;
+        }
         NSData *inData = [tileData objectAtIndex:ii];
         if (![inData isKindOfClass:[NSData class]])
             continue;

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/GeoJSONSource.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/GeoJSONSource.mm
@@ -1,10 +1,20 @@
-//
-//  GeoJSONSource.m
-//  AutoTester
-//
-//  Created by Ranen Ghosh on 2016-11-18.
-//  Copyright © 2016-2019 mousebird consulting.
-//
+/*  GeoJSONSource.mm
+ *  WhirlyGlobe-MaplyComponent
+ *
+ *  Created by Ranen Ghosh on 2016-11-18.
+ *  Copyright 2016-2021 mousebird consulting
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 
 #import <UIKit/UIKit.h>
 #import "loading/GeoJSONSource.h"
@@ -147,10 +157,7 @@ using namespace WhirlyKit;
             for (MaplyVectorObject *vecObj in vectorObjs) {
                 vecObj->vObj->setAttributes(attrDict);
             }
-
         }
-        
-        
         
         NSArray *symbolizerKeys = [featureStyles.allKeys sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"self" ascending:YES]]];
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MapboxVectorInterpreter.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MapboxVectorInterpreter.mm
@@ -185,6 +185,9 @@ static int BackImageWidth = 16, BackImageHeight = 16;
     // Uncompress any of the data we recieved
     NSArray *tileData = [loadReturn getTileData];
     for (unsigned int ii=0;ii<[tileData count];ii++) {
+        if (loadReturn.isCancelled) {
+            return;
+        }
         NSData *thisTileData = [tileData objectAtIndex:ii];
         if(thisTileData) {
           if([thisTileData isCompressed]) {
@@ -279,6 +282,10 @@ static int BackImageWidth = 16, BackImageHeight = 16;
     // Parse everything else and turn into vectors
     std::vector<ComponentObjectRef> compObjs,ovlCompObjs;
     for (NSData *thisTileData : pbfDatas) {
+        if (loadReturn.isCancelled) {
+            return;
+        }
+
         // Use a separate work item for each tile, so that we react quickly if told to shut down
         WorkRegion wr(vc);
         if (!wr) {

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorStyle.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorStyle.mm
@@ -1,5 +1,4 @@
-/*
- *  MaplyVectorStyle.mm
+/*  MaplyVectorStyle.mm
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "vector_tiles/MapboxVectorTiles.h"
@@ -751,7 +749,11 @@ void VectorStyleWrapper::buildObjects(PlatformThreadInfo *inst,
             nsDesc = [NSMutableDictionary fromDictionaryCPointer:desc];
         }
 
-        [style buildObjects:vecArray forTile:tileData viewC:viewC desc:nsDesc];
+        [style buildObjects:vecArray
+                    forTile:tileData
+                      viewC:viewC
+                       desc:nsDesc
+                   cancelFn:^{return cancelFn(nullptr);}];
     }
 }
 

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorStyle.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorStyle.mm
@@ -709,20 +709,26 @@ bool VectorStyleWrapper::geomAdditive(PlatformThreadInfo *inst)
 void VectorStyleWrapper::buildObjects(PlatformThreadInfo *inst,
                                       const std::vector<VectorObjectRef> &vecObjs,
                                       const VectorTileDataRef &tileInfo,
-                                      const Dictionary *desc)
+                                      const Dictionary *desc,
+                                      const CancelFunction &cancelFn)
 {
     if (auto tileData = [[MaplyVectorTileData alloc] init])
     {
         tileData->data = tileInfo;
 
         NSMutableArray *vecArray = [NSMutableArray array];
-        for (VectorObjectRef vecObj: vecObjs)
+        for (auto &vecObj: vecObjs)
         {
             if (auto mVecObj = [[MaplyVectorObject alloc] init])
             {
                 mVecObj->vObj = vecObj;
                 [vecArray addObject:mVecObj];
             }
+        }
+
+        if (cancelFn(inst))
+        {
+            return;
         }
 
         NSDictionary* nsDesc = nil;
@@ -734,6 +740,7 @@ void VectorStyleWrapper::buildObjects(PlatformThreadInfo *inst,
         {
             nsDesc = [NSMutableDictionary fromDictionaryCPointer:desc];
         }
+
         [style buildObjects:vecArray forTile:tileData viewC:viewC desc:nsDesc];
     }
 }

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorStyle.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorStyle.mm
@@ -295,12 +295,22 @@ using namespace WhirlyKit;
                viewC:(NSObject<MaplyRenderControllerProtocol> *_Nonnull)viewC
                 desc:(NSDictionary *_Nullable)desc
 {
+    [self buildObjects:vecObjs forTile:tileData viewC:viewC desc:desc cancelFn:nil];
+}
+
+- (void)buildObjects:(NSArray *_Nonnull)vecObjs
+             forTile:(MaplyVectorTileData *_Nonnull)tileData
+               viewC:(NSObject<MaplyRenderControllerProtocol> *_Nonnull)viewC
+                desc:(NSDictionary *_Nullable)desc
+            cancelFn:(bool(^)(void))cancelFn
+{
     std::vector<VectorObjectRef> localVecObjs;
     for (MaplyVectorObject *vecObj in vecObjs)
         localVecObjs.push_back(vecObj->vObj);
 
     auto lDesc = desc ? iosMutableDictionary(desc) : iosMutableDictionary();
-    vectorStyle->buildObjects(nullptr, localVecObjs, tileData->data, &lDesc);
+    vectorStyle->buildObjects(nullptr, localVecObjs, tileData->data, &lDesc,
+                              [=](auto){return cancelFn && cancelFn();});
 }
 
 @end

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorStyleSimple.m
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorStyleSimple.m
@@ -1,10 +1,20 @@
-//
-//  MaplyVectorStyleSimple.m
-//  WhirlyGlobe-MaplyComponent
-//
-//  Created by Steve Gifford on 3/15/16.
-//
-//
+/*  MaplyVectorStyleSimple.m
+ *  WhirlyGlobe-MaplyComponent
+ *
+ *  Created by Steve Gifford on 3/15/16.
+ *  Copyright 2011-2021 mousebird consulting
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 
 #import "vector_styles/MaplyVectorStyleSimple.h"
 #import "visual_objects/MaplyScreenLabel.h"
@@ -130,6 +140,15 @@
 {
 }
 
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileData
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)desc
+            cancelFn:(bool(^__nullable)(void))cancelFn
+{
+}
+
 @end
 
 @implementation MaplyVectorStyleSimplePolygon
@@ -149,6 +168,16 @@
              forTile:(MaplyVectorTileData *)tileInfo
                viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
                 desc:(NSDictionary * _Nullable)extraDesc
+{
+    [self buildObjects:vecObjs forTile:tileInfo viewC:viewC desc:extraDesc cancelFn:nil];
+}
+
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileInfo
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)extraDesc
+            cancelFn:(bool(^__nullable)(void))cancelFn
 {
     NSMutableArray *tessObjs = [NSMutableArray array];
     for (MaplyVectorObject *vecObj in vecObjs)
@@ -190,6 +219,16 @@
              forTile:(MaplyVectorTileData *)tileInfo
                viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
                 desc:(NSDictionary * _Nullable)extraDesc
+{
+    [self buildObjects:vecObjs forTile:tileInfo viewC:viewC desc:extraDesc cancelFn:nil];
+}
+
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileInfo
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)extraDesc
+            cancelFn:(bool(^__nullable)(void))cancelFn
 {
     NSMutableArray *labels = [NSMutableArray array];
     
@@ -245,6 +284,16 @@
              forTile:(MaplyVectorTileData *)tileInfo
                viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
                 desc:(NSDictionary * _Nullable)extraDesc
+{
+    [self buildObjects:vecObjs forTile:tileInfo viewC:viewC desc:extraDesc cancelFn:nil];
+}
+
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileInfo
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)extraDesc
+            cancelFn:(bool(^__nullable)(void))cancelFn
 {
     NSDictionary *desc = @{
         kMaplyColor: _color,

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileLineStyle.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileLineStyle.mm
@@ -1,9 +1,8 @@
-/*
- *  MaplyVectorLineStyle.mm
+/*  MaplyVectorLineStyle.mm
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import <vector>
@@ -157,6 +155,16 @@
              forTile:(MaplyVectorTileData *)tileInfo
                viewC:(NSObject<MaplyRenderControllerProtocol> *)viewC
                 desc:(NSDictionary * _Nullable)extraDesc
+{
+    [self buildObjects:vecObjs forTile:tileInfo viewC:viewC desc:extraDesc cancelFn:nil];
+}
+
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileInfo
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)extraDesc
+            cancelFn:(bool(^__nullable)(void))cancelFn
 {
     MaplyComponentObject *baseWideObj = nil;
     MaplyComponentObject *baseRegObj = nil;

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileMarkerStyle.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileMarkerStyle.mm
@@ -1,9 +1,8 @@
-/*
- *  MaplyVectorMarkerStyle.h
+/*  MaplyVectorMarkerStyle.h
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "vector_styles/MaplyVectorTileMarkerStyle.h"
@@ -141,6 +139,16 @@
              forTile:(MaplyVectorTileData *)tileInfo
                viewC:(NSObject<MaplyRenderControllerProtocol> *)viewC
                 desc:(NSDictionary * _Nullable)extraDesc
+{
+    [self buildObjects:vecObjs forTile:tileInfo viewC:viewC desc:extraDesc cancelFn:nil];
+}
+
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileInfo
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)extraDesc
+            cancelFn:(bool(^__nullable)(void))cancelFn
 {
     const bool isRetina = [UIScreen mainScreen].scale > 1.0;
 

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTilePolygonStyle.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTilePolygonStyle.mm
@@ -1,9 +1,8 @@
-/*
- *  MaplyVectorPolygonStyle.mm
+/*  MaplyVectorPolygonStyle.mm
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "control/WhirlyGlobeViewController.h"
@@ -100,9 +98,19 @@
 }
 
 - (void)buildObjects:(NSArray *)vecObjs
-             forTile:(MaplyVectorTileData *)tileData
+             forTile:(MaplyVectorTileData *)tileInfo
                viewC:(NSObject<MaplyRenderControllerProtocol> *)viewC
                 desc:(NSDictionary * _Nullable)extraDesc
+{
+    [self buildObjects:vecObjs forTile:tileInfo viewC:viewC desc:extraDesc cancelFn:nil];
+}
+
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileData
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)extraDesc
+            cancelFn:(bool(^__nullable)(void))cancelFn
 {
     MaplyComponentObject *baseObj = nil;
     NSMutableArray *compObjs = [NSMutableArray array];

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileStyle.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileStyle.mm
@@ -1,9 +1,8 @@
-/*
- *  MaplyVectorStyle.mm
+/*  MaplyVectorTileStyle.mm
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "vector_styles/MaplyVectorStyle.h"
@@ -154,6 +152,14 @@ using namespace WhirlyKit;
 {
 }
 
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileInfo
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)extraDesc
+            cancelFn:(bool(^__nullable)(void))cancelFn
+{
+}
 
 //sometimes we get strings that look like [name]+'\n '+[ele]
 - (NSString*)formatText:(NSString*)formatString forObject:(MaplyVectorObject*)vec

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileTextStyle.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/vector_tiles/MaplyVectorTileTextStyle.mm
@@ -1,9 +1,8 @@
-/*
- *  MaplyVectorTextStyle.mm
+/*  MaplyVectorTextStyle.mm
  *  WhirlyGlobe-MaplyComponent
  *
  *  Created by Steve Gifford on 1/3/14.
- *  Copyright 2011-2019 mousebird consulting
+ *  Copyright 2011-2021 mousebird consulting
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -15,7 +14,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "vector_styles/MaplyVectorTileTextStyle.h"
@@ -253,6 +251,16 @@ typedef enum {
              forTile:(MaplyVectorTileData *)tileInfo
                viewC:(NSObject<MaplyRenderControllerProtocol> *)viewC
                 desc:(NSDictionary * _Nullable)extraDesc
+{
+    [self buildObjects:vecObjs forTile:tileInfo viewC:viewC desc:extraDesc cancelFn:nil];
+}
+
+/// Construct objects related to this style based on the input data.
+- (void)buildObjects:(NSArray * _Nonnull)vecObjs
+             forTile:(MaplyVectorTileData * __nonnull)tileInfo
+               viewC:(NSObject<MaplyRenderControllerProtocol> * _Nonnull)viewC
+                desc:(NSDictionary * _Nullable)extraDesc
+            cancelFn:(bool(^__nullable)(void))cancelFn
 {
     MaplyCoordinateSystem *displaySystem = viewC.coordSystem;
 


### PR DESCRIPTION
Android map seems more responsive, and a stack trace grabbed while shutting down after initiating many tile loads no longer contains a lot of `buildObjects` activity.  Also confirmed that `buildObejcts` is actually canceled on iOS, though it seems to be less important there.