### PR TITLE
Fix texture coordinates when clipping the bottom edge of tiles.

### DIFF
--- a/common/WhirlyGlobeLib/src/QuadTreeNew.cpp
+++ b/common/WhirlyGlobeLib/src/QuadTreeNew.cpp
@@ -69,10 +69,7 @@ bool QuadTreeNew::Node::operator!=(const WhirlyKit::QuadTreeNew::Node &that) con
 
 MbrD QuadTreeNew::generateMbrForNode(const Node &node) const
 {
-    Point2d chunkSize = mbr.span();
-    chunkSize.x() /= (1<<node.level);
-    chunkSize.y() /= (1<<node.level);
-
+    const Point2d chunkSize = mbr.span() / (1 << node.level);
     return {Point2d(chunkSize.x()*node.x,chunkSize.y()*node.y) + mbr.ll(),
             Point2d(chunkSize.x()*(node.x+1),chunkSize.y()*(node.y+1)) + mbr.ll()};
 }

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/math/MaplyCoordinate.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/math/MaplyCoordinate.h
@@ -251,6 +251,17 @@ MaplyCoordinate3d MaplyCoordinate3dMake(float x,float y,float z);
  */
 MaplyCoordinate3dD MaplyCoordinate3dDMake(double x,double y,double z);
 
+/**
+    Construct a float bounding box from a double bounding box
+ */
+MaplyBoundingBox MaplyBoundingBoxMakeFromBoundingBoxD(MaplyBoundingBoxD mbr);
+
+/**
+    Construct a double bounding box from a float bounding box
+ */
+MaplyBoundingBoxD MaplyBoundingBoxDMakeFromBoundingBox(MaplyBoundingBox mbr);
+
+
 /** 
     Construct a MaplyBoundingBox from the values given.
     

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/math/MaplyCoordinate.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/math/MaplyCoordinate.mm
@@ -50,6 +50,13 @@ inline MaplyBoundingBoxD MaplyBoundingBoxDMakeFromMbrD(MbrD mbr) {
     return { MaplyCoordinateDMake(mbr.ll().x(), mbr.ll().y()), MaplyCoordinateDMake(mbr.ur().x(), mbr.ur().y()) };
 }
 
+MaplyBoundingBox MaplyBoundingBoxMakeFromBoundingBoxD(MaplyBoundingBoxD mbr) {
+    return { MaplyCoordinateMakeWithMaplyCoordinateD(mbr.ll), MaplyCoordinateMakeWithMaplyCoordinateD(mbr.ur) };
+}
+MaplyBoundingBoxD MaplyBoundingBoxDMakeFromBoundingBox(MaplyBoundingBox mbr) {
+    return { MaplyCoordinateDMakeWithMaplyCoordinate(mbr.ll), MaplyCoordinateDMakeWithMaplyCoordinate(mbr.ur) };
+}
+
 MaplyBoundingBox MaplyBoundingBoxMakeWithDegrees(float degLon0,float degLat0,float degLon1,float degLat1)
 {
     return {


### PR DESCRIPTION
Draw tiles when they overlap the clipping area rather than when their centroid falls within it.