### PR TITLE
Add the option to only load the current frame(s)

### DIFF
--- a/ios/apps/AutoTester/AutoTester/testCases/ParticleTest.mm
+++ b/ios/apps/AutoTester/AutoTester/testCases/ParticleTest.mm
@@ -273,7 +273,7 @@ void main()
     _coordSys = [[MaplySphericalMercator alloc] initWebStandard];
     viewC = inViewC;
     
-    MaplyParticleSystemType partSysType = MaplyParticleSystemTypeRectangle;
+    //MaplyParticleSystemType partSysType = MaplyParticleSystemTypeRectangle;
     
     // These govern how the particles are structured
     _updateInterval = 0.05;
@@ -432,7 +432,7 @@ void main()
 {
     char tileStr[100];
     // Letting NSString do this is sloooow
-    sprintf(tileStr,"%d_%d_%d",tileID.x,tileID.y,tileID.level);
+    snprintf(tileStr,sizeof(tileStr),"%d_%d_%d",tileID.x,tileID.y,tileID.level);
     return [[NSString alloc] initWithUTF8String:tileStr];
 }
 

--- a/ios/library/WhirlyGlobe-MaplyComponent/include/loading/MaplyQuadImageFrameLoader.h
+++ b/ios/library/WhirlyGlobe-MaplyComponent/include/loading/MaplyQuadImageFrameLoader.h
@@ -92,11 +92,29 @@ typedef NS_ENUM(NSInteger, MaplyLoadFrameMode) {
  @param params The sampling parameters describing how to break down the data for projection onto a globe or map.
  @param tileInfos A list of tile info objects to fetch for each frame.
  @param viewC the View controller (or renderer) to add objects to.
+ @param loadAllFrames Whether we load frames not currently being displayed
  */
-- (nullable instancetype)initWithParams:(MaplySamplingParams *__nonnull)params tileInfos:(NSArray<NSObject<MaplyTileInfoNew> *> *__nonnull)tileInfos viewC:(NSObject<MaplyRenderControllerProtocol> *__nonnull)viewC;
+- (nullable instancetype)initWithParams:(MaplySamplingParams *__nonnull)params
+                              tileInfos:(NSArray<NSObject<MaplyTileInfoNew> *> *__nonnull)tileInfos
+                                  viewC:(NSObject<MaplyRenderControllerProtocol> *__nonnull)viewC
+                          loadAllFrames:(bool)loadAllFrames;
+
+/**
+ Initialize with multiple tile sources (one per frame).
+ 
+ @param params The sampling parameters describing how to break down the data for projection onto a globe or map.
+ @param tileInfos A list of tile info objects to fetch for each frame.
+ @param viewC the View controller (or renderer) to add objects to.
+ */
+- (nullable instancetype)initWithParams:(MaplySamplingParams *__nonnull)params
+                              tileInfos:(NSArray<NSObject<MaplyTileInfoNew> *> *__nonnull)tileInfos
+                                  viewC:(NSObject<MaplyRenderControllerProtocol> *__nonnull)viewC;
 
 /// How frames are loaded (top down vs broad)
 @property (nonatomic,assign) MaplyLoadFrameMode loadFrameMode;
+
+/// Whether we load frames not currently being displayed
+@property (nonatomic,assign) bool loadAllFrames;
 
 /**
   Add another rendering focus to the frame loader.

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/data_sources/MaplyMBTileFetcher.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/data_sources/MaplyMBTileFetcher.mm
@@ -42,6 +42,13 @@ using namespace WhirlyKit;
                                cacheSize:(int)cacheSize
 {
     NSString *infoPath = nil;
+    
+    // fileExistsAtPath can't handle file URLs
+    if (NSURL* url = [NSURL URLWithString:mbTilesName])
+    {
+        mbTilesName = url.path;
+    }
+
     // See if that was a direct path first
     if ([[NSFileManager defaultManager] fileExistsAtPath:mbTilesName])
         infoPath = mbTilesName;

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/loading/MaplyQuadImageFrameLoader.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/loading/MaplyQuadImageFrameLoader.mm
@@ -1,5 +1,4 @@
-/*
- *  MaplyQuadImageFrameLoader.mm
+/*  MaplyQuadImageFrameLoader.mm
  *
  *  Created by Steve Gifford on 9/13/18.
  *  Copyright 2012-2022 mousebird consulting inc
@@ -14,7 +13,6 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
  */
 
 #import "loading/MaplyQuadImageFrameLoader.h"
@@ -123,7 +121,17 @@ NSString * const MaplyQuadImageLoaderFetcherName = @"QuadImageLoader";
     bool started;
 }
 
-- (nullable instancetype)initWithParams:(MaplySamplingParams *__nonnull)inParams tileInfos:(NSArray<NSObject<MaplyTileInfoNew> *> *__nonnull)frameInfos viewC:(NSObject<MaplyRenderControllerProtocol> * __nonnull)inViewC
+- (nullable instancetype)initWithParams:(MaplySamplingParams *__nonnull)inParams
+                              tileInfos:(NSArray<NSObject<MaplyTileInfoNew> *> *__nonnull)frameInfos
+                                  viewC:(NSObject<MaplyRenderControllerProtocol> * __nonnull)inViewC
+{
+    return [self initWithParams:inParams tileInfos:frameInfos viewC:inViewC loadAllFrames:true];
+}
+
+- (nullable instancetype)initWithParams:(MaplySamplingParams *__nonnull)inParams
+                              tileInfos:(NSArray<NSObject<MaplyTileInfoNew> *> *__nonnull)frameInfos
+                                  viewC:(NSObject<MaplyRenderControllerProtocol> * __nonnull)inViewC
+                          loadAllFrames:(bool)loadAllFrames
 {
     if (!inParams.singleLevel) {
         NSLog(@"MaplyQuadImageFrameLoader only supports samplers with singleLevel set to true");
@@ -131,13 +139,17 @@ NSString * const MaplyQuadImageLoaderFetcherName = @"QuadImageLoader";
     }
     self = [super initWithViewC:inViewC];
 
+    _loadAllFrames = loadAllFrames;
+
     params = inParams->params;
     params.generateGeom = true;
 
+    constexpr auto frameMode = QuadImageFrameLoader::MultiFrame;
+    const auto frameLoadMode = loadAllFrames ? QuadImageFrameLoader::FrameLoadMode::All :
+                                               QuadImageFrameLoader::FrameLoadMode::Current;
+
     // Loader does all the work.  The Obj-C version is just a wrapper
-    self->loader = QuadImageFrameLoader_iosRef(new QuadImageFrameLoader_ios(params,
-                                                                            frameInfos,
-                                                                            QuadImageFrameLoader::MultiFrame));
+    self->loader = std::make_shared<QuadImageFrameLoader_ios>(params, frameInfos, frameMode, frameLoadMode);
     
     self.baseDrawPriority = kMaplyImageLayerDrawPriorityDefault;
     self.drawPriorityPerLevel = 100;
@@ -180,6 +192,45 @@ NSString * const MaplyQuadImageLoaderFetcherName = @"QuadImageLoader";
     [self updatePriorities];
 }
 
+- (void)uploadLoadAllFrames:(NSNumber*)loadAll
+{
+    const auto __strong thread = samplingLayer.layerThread;
+    if (loadAll.boolValue == _loadAllFrames || !thread)
+    {
+        return;
+    }
+
+    _loadAllFrames = loadAll;
+
+    //const bool opt = loadAll.boolValue;
+    const auto opt = loadAll.boolValue ? QuadImageFrameLoader::FrameLoadMode::All :
+                                         QuadImageFrameLoader::FrameLoadMode::Current;
+
+    ChangeSet changes;
+    loader->setFrameLoadMode(opt, nil, changes);
+    [thread addChangeRequests:changes];
+}
+
+- (void)setLoadAllFrames:(bool)loadAll
+{
+    const auto ldr = self->loader;
+    const auto __strong thread = samplingLayer.layerThread;
+    if (loadAll == _loadAllFrames || !ldr || !thread)
+    {
+        return;
+    }
+
+    NSNumber *opt = [NSNumber numberWithBool:loadAll];
+    if ([NSThread currentThread] == thread)
+    {
+        [self uploadLoadAllFrames:opt];
+    }
+    else
+    {
+        [self performSelector:@selector(uploadLoadAllFrames:) onThread:thread withObject:opt waitUntilDone:NO];
+    }
+}
+
 - (bool)delayedInit
 {
     started = true;
@@ -215,19 +266,50 @@ NSString * const MaplyQuadImageLoaderFetcherName = @"QuadImageLoader";
     [self setFocus:0 currentImage:where];
 }
 
+- (void)runSetFocus:(NSArray<NSNumber*>*)obj
+{
+    const auto ldr = self->loader;
+    const auto __strong thread = samplingLayer.layerThread;
+    if (!ldr || !thread)
+    {
+        return;
+    }
+
+    const int focusID = obj[0].intValue;
+    const double where = obj[1].doubleValue;
+
+    const double newFrame = std::min(std::max(where,0.0),(double)([ldr->frameInfos count]-1));
+    const double oldFrame = ldr->getCurFrame(focusID);
+
+    ChangeSet changes;
+    loader->setCurFrame(nullptr, focusID, newFrame, changes);
+    [thread addChangeRequests:changes];
+
+    // Update the loading priorities if we're in narrow mode and we changed images
+    if (_loadFrameMode != MaplyLoadFrameBroad && floor(newFrame) != floor(oldFrame))
+    {
+        ldr->updatePriorities(nullptr);
+    }
+}
+
 - (void)setFocus:(int)focusID currentImage:(double)where
 {
-    double curFrame = std::min(std::max(where,0.0),(double)([loader->frameInfos count]-1));
-    double oldFrame = loader->getCurFrame(focusID);
-    loader->setCurFrame(NULL, focusID, curFrame);
-    
-    // Update the loading priorities if we're in narrow mode and we changed images
-    if (_loadFrameMode != MaplyLoadFrameBroad) {
-        int oldInt = oldFrame;
-        int newInt = curFrame;
+    const auto ldr = self->loader;
+    const auto __strong thread = samplingLayer.layerThread;
+    if (!ldr || !thread)
+    {
+        return;
+    }
 
-        if (oldInt != newInt)
-            [self updatePriorities];
+    NSArray *obj = @[ [NSNumber numberWithInt:focusID],
+                      [NSNumber numberWithDouble:where] ];
+    if ([NSThread currentThread] == thread)
+    {
+        [self runSetFocus:obj];
+    }
+    else
+    {
+        [self performSelector:@selector(runSetFocus:) onThread:thread withObject:obj waitUntilDone:NO];
     }
 }
 

--- a/ios/library/WhirlyGlobe-MaplyComponent/src/loading/MaplyQuadLoader.mm
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/loading/MaplyQuadLoader.mm
@@ -442,7 +442,8 @@ using namespace WhirlyKit;
         return;
     
     if (loader->getDebugMode())
-        NSLog(@"MaplyQuadImageLoader: Got fetch back for tile %d: (%d,%d) frame %d",tileID.level,tileID.x,tileID.y,frame);
+        NSLog(@"MaplyQuadImageLoader '%s': Got fetch back for tile %d: (%d,%d) frame %d",
+              loader->getLabel().c_str(), tileID.level,tileID.x,tileID.y,frame);
     
     MaplyLoaderReturn *loadData = nil;
     if ([data isKindOfClass:[MaplyLoaderReturn class]]) {
@@ -456,7 +457,8 @@ using namespace WhirlyKit;
         if ([data isKindOfClass:[NSData class]]) {
             [loadData addTileData:data];
         } else if (data != nil) {
-            NSLog(@"MaplyQuadLader:fetchRequestSuccess: client return unknown data type.  Dropping.");
+            NSLog(@"MaplyQuadImageLoader '%s': fetchRequestSuccess: client return unknown data type.  Dropping.",
+                  loader->getLabel().c_str());
         }
     }
 

--- a/ios/library/WhirlyGlobeLib/include/QuadImageFrameLoader_iOS.h
+++ b/ios/library/WhirlyGlobeLib/include/QuadImageFrameLoader_iOS.h
@@ -109,10 +109,18 @@ class QuadImageFrameLoader_ios : public QuadImageFrameLoader
 {
 public:
     // Displaying a single frame
-    QuadImageFrameLoader_ios(const SamplingParams &params,NSObject<MaplyTileInfoNew> *inTileInfo,Mode mode);
+    QuadImageFrameLoader_ios(const SamplingParams &params,
+                             NSObject<MaplyTileInfoNew> *inTileInfo,
+                             Mode mode,
+                             FrameLoadMode frameMode = FrameLoadMode::All);
+
     // Displaying multiple animated frames (or one with multiple data sources)
-    QuadImageFrameLoader_ios(const SamplingParams &params,NSArray<NSObject<MaplyTileInfoNew> *> *inFrameInfos,Mode mode);
-    ~QuadImageFrameLoader_ios();
+    QuadImageFrameLoader_ios(const SamplingParams &params,
+                             NSArray<NSObject<MaplyTileInfoNew> *> *inFrameInfos,
+                             Mode mode,
+                             FrameLoadMode frameMode = FrameLoadMode::All);
+
+    virtual ~QuadImageFrameLoader_ios() = default;
         
     NSObject<MaplyTileFetcher> * __weak tileFetcher;
     NSArray<NSObject<MaplyTileInfoNew> *> *frameInfos;


### PR DESCRIPTION
Pretty straightforward.  Worst part is that changing the current frame can now produce changes and so has to be thread-managed, but I left the old call signature in for cases where you know that's not relevant.

I haven't really done anything with "focus," so I'm not sure I handled that correctly, but there's a current frame per focus so I treated a frame set as current on any focus as "active."

