### PR TITLE
Add a fourth, dummy vertex to the location tracker direction arrow to satisfy `drawVertices`

### DIFF
--- a/android/library/maply/src/main/java/com/mousebird/maply/BaseController.java
+++ b/android/library/maply/src/main/java/com/mousebird/maply/BaseController.java
@@ -1100,6 +1100,13 @@ public abstract class BaseController implements RenderController.TaskManager, Re
 				}
 			}
 
+			int[] ranges = new int[2];
+			int[] precisions = new int[1];
+			GLES20.glGetShaderPrecisionFormat(GLES20.GL_VERTEX_SHADER, GLES20.GL_HIGH_FLOAT, ranges, 0, precisions, 0);
+			if (!LayerThread.checkGLError(egl, "glGetShaderPrecisionFormat") && precisions[0] < 23) {
+				Log.w("Maply", "Vertex precision is only " + precisions[0]);
+			}
+
 			rendererAttached = true;
 
 			// Call the post surface setup callbacks

--- a/android/library/maply/src/main/java/com/mousebird/maply/LocationTracker.kt
+++ b/android/library/maply/src/main/java/com/mousebird/maply/LocationTracker.kt
@@ -609,21 +609,20 @@ class LocationTracker : LocationCallback {
 
         val radius = size / 2.0f
 
-        if (directional) {
+        // https://developer.android.com/topic/performance/hardware-accel#unsupported
+        if (directional && (!canvas.isHardwareAccelerated || Build.VERSION.SDK_INT >= 30)) {
             val len = size * 5 / 16f
             val width = size * 3 / 16f
-            //paint.color = markerColorOuter
-            //paint.alpha = Color.alpha(markerColorOuter)
-            val vertexes = floatArrayOf(radius, radius - gradRadius - len,
-                    radius - width, radius - gradRadius,
-                    radius + width, radius - gradRadius)
-            val indexes = shortArrayOf(0, 1, 2)
-            val colors = intArrayOf(markerColorOuter, markerColorOuter, markerColorOuter)
+            val vertexes = floatArrayOf(radius,         radius - gradRadius - len,
+                                        radius - width, radius - gradRadius,
+                                        radius + width, radius - gradRadius,
+                                        radius + width, radius - gradRadius)    // "vertexCount must be a multiple of 2."
+            val colors = Array(vertexes.size) { markerColorOuter }.toIntArray()
             canvas.drawVertices(Canvas.VertexMode.TRIANGLES,
                     vertexes.size, vertexes, 0,
                     null, 0,
                     colors, 0,
-                    indexes, 0, indexes.size,
+                    null, 0, 0,
                     paint)
         }
 


### PR DESCRIPTION
Skip the same if it's not supported, according to the referenced documentation.
Remove unnecessary indexes array, ensure that color array size matches vertices.
Include unrelated shader precision check.