### PR TITLE
Import functional header to support `std::function` in RawData.h

### DIFF
--- a/common/WhirlyGlobeLib/include/RawData.h
+++ b/common/WhirlyGlobeLib/include/RawData.h
@@ -20,6 +20,7 @@
 #import <vector>
 #import <string>
 #import <memory>
+#include <functional>
 #import "WhirlyTypes.h"
 
 namespace WhirlyKit


### PR DESCRIPTION
Bitrise build was failed in M1 with the following error.

`platform=iOS" | xcpretty):
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/include/RawData.h:51:64: error: no template named 'function' in namespace 'std'
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/include/RawData.h:65:10: error: no template named 'function' in namespace 'std'
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/include/RawData.h:51:64: error: no template named 'function' in namespace 'std'
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/include/RawData.h:65:10: error: no template named 'function' in namespace 'std'
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/src/Texture.cpp:78:12: error: no viable conversion from returned value of type 'shared_ptr<WhirlyKit::RawDataWrapper>' to function return type 'shared_ptr<RawData>'
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/src/Texture.cpp:102:12: error: no viable conversion from returned value of type 'shared_ptr<WhirlyKit::RawDataWrapper>' to function return type 'shared_ptr<RawData>'
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/src/Texture.cpp:125:12: error: no viable conversion from returned value of type 'shared_ptr<WhirlyKit::RawDataWrapper>' to function return type 'shared_ptr<RawData>'
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/src/Texture.cpp:151:12: error: no viable conversion from returned value of type 'shared_ptr<WhirlyKit::RawDataWrapper>' to function return type 'shared_ptr<RawData>'
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/src/Texture.cpp:177:12: error: no viable conversion from returned value of type 'shared_ptr<WhirlyKit::RawDataWrapper>' to function return type 'shared_ptr<RawData>'
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/src/Texture.cpp:215:12: error: no viable conversion from returned value of type 'shared_ptr<WhirlyKit::RawDataWrapper>' to function return type 'shared_ptr<RawData>'
      /Users/[REDACTED]/git/Pods/WhirlyGlobe/common/WhirlyGlobeLib/src/Texture.cpp:247:12: error: no viable conversion from returned value of type 'shared_ptr<WhirlyKit::RawDataWrapper>' to function return type 'shared_ptr<RawData>'`
      
      So, Imported functional header to support std::function in RawData.h  