### PR TITLE
Enforce TLS 1.2 as the minimum protocol version in MaplyURLSessionManager to ensure secure network communication

### DIFF
--- a/ios/library/WhirlyGlobe-MaplyComponent/src/http/URLSession/private/MaplyURLSessionManager+Private.m
+++ b/ios/library/WhirlyGlobe-MaplyComponent/src/http/URLSession/private/MaplyURLSessionManager+Private.m
@@ -12,11 +12,17 @@
 
 -(NSURLSession*)createURLSession{
      
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     
-    NSURLSession * session = [NSURLSession sessionWithConfiguration:NSURLSessionConfiguration.defaultSessionConfiguration
+    if (@available(iOS 13, tvOS 13, watchOS 6, macOS 10.15, *)) {
+        configuration.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12;
+    } else {
+        configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
+    }
+    
+    NSURLSession * session = [NSURLSession sessionWithConfiguration:configuration
                                                            delegate:(id <NSURLSessionDelegate>)self
                                                       delegateQueue:NSOperationQueue.mainQueue];
-    
     
     return session;
 }


### PR DESCRIPTION
Modified MaplyURLSessionManager to enforce a minimum TLS version of 1.2 for URLSession connections. This change disables outdated and insecure protocols such as SSLv2, SSLv3, TLSv1.0, and TLSv1.1. Enforcing TLS 1.2+ helps ensure secure data transmission and complies with security standards recommended by code scanning tools like Fortify and SonarQube.